### PR TITLE
Add user settings page

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,71 @@
+class SettingsController < ApplicationController
+  def show
+    @user = Current.user
+    @api_token = @user.api_tokens.active.first
+  end
+
+  def update_profile
+    @user = Current.user
+
+    if @user.update(profile_params)
+      redirect_to settings_path, notice: "Profile updated successfully."
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  def update_password
+    @user = Current.user
+
+    unless @user.authenticate(params[:current_password])
+      redirect_to settings_path, alert: "Current password is incorrect."
+      return
+    end
+
+    if @user.update(password_params)
+      redirect_to settings_path, notice: "Password changed successfully."
+    else
+      redirect_to settings_path, alert: @user.errors.full_messages.join(", ")
+    end
+  end
+
+  def toggle_tailscale
+    @user = Current.user
+
+    if @user.update(tailscale_auto_connect: !@user.tailscale_auto_connect)
+      status = @user.tailscale_auto_connect ? "enabled" : "disabled"
+      redirect_to settings_path, notice: "Tailscale auto-connect #{status}."
+    else
+      redirect_to settings_path, alert: "Failed to update Tailscale settings."
+    end
+  end
+
+  def generate_token
+    @user = Current.user
+
+    # Revoke existing token if present
+    @user.api_tokens.active.destroy_all
+
+    token, raw_token = ApiToken.generate_for(@user, name: "Web UI Token")
+
+    flash[:api_token] = raw_token
+    redirect_to settings_path, notice: "API token generated. Make sure to copy it now - you won't be able to see it again!"
+  end
+
+  def revoke_token
+    @user = Current.user
+    @user.api_tokens.active.destroy_all
+
+    redirect_to settings_path, notice: "API token revoked."
+  end
+
+  private
+
+  def profile_params
+    params.require(:user).permit(:email_address)
+  end
+
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,4 +46,8 @@ class User < ApplicationRecord
   def tailscale_disabled?
     !respond_to?(:tailscale_state) || tailscale_state == "disabled"
   end
+
+  def tailscale_auto_connect?
+    tailscale_auto_connect
+  end
 end

--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -137,6 +137,23 @@ sandcastle snapshot list
 sandcastle create my-dev-v2 --snapshot my-checkpoint</code></pre>
   </section>
 
+  <%# ── Settings ── %>
+  <section class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 mb-3">10. User settings</h2>
+    <p class="text-gray-700 mb-3">
+      Click <strong>Settings</strong> in the navbar to manage your account preferences:
+    </p>
+    <ul class="list-disc list-inside text-gray-700 ml-4 space-y-1 text-sm">
+      <li><strong>Profile</strong> — Update your email address and change your password</li>
+      <li><strong>Tailscale</strong> — View connection status and toggle auto-connect for new sandboxes</li>
+      <li><strong>API Token</strong> — Generate or revoke your API token for CLI authentication</li>
+    </ul>
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mt-4 text-sm text-blue-800">
+      <strong>Using API tokens:</strong> After generating a token in Settings, configure the CLI with<br>
+      <code class="bg-blue-100 px-1 rounded">sandcastle config set-token</code> and paste your token when prompted.
+    </div>
+  </section>
+
   <div class="border-t border-gray-200 pt-6 text-center">
     <p class="text-sm text-gray-500">
       Run <code class="bg-gray-100 px-1.5 py-0.5 rounded">sandcastle --help</code> for the full command reference.

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,0 +1,172 @@
+<div class="max-w-3xl mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold text-gray-900 mb-8">Settings</h1>
+
+  <% if flash[:api_token] %>
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+      <p class="text-sm font-medium text-blue-800 mb-2">Your new API token (save this now - you won't see it again!):</p>
+      <div class="flex items-center gap-2">
+        <code class="flex-1 bg-blue-100 text-blue-900 px-3 py-2 rounded font-mono text-sm break-all"><%= flash[:api_token] %></code>
+        <button onclick="navigator.clipboard.writeText('<%= flash[:api_token] %>')"
+                class="px-3 py-2 bg-blue-600 text-white text-xs rounded hover:bg-blue-700 whitespace-nowrap">
+          Copy
+        </button>
+      </div>
+    </div>
+  <% end %>
+
+  <%# ── Profile Section ── %>
+  <div class="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Profile</h2>
+
+    <div class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+        <div class="text-sm text-gray-900 font-mono bg-gray-50 px-3 py-2 rounded border border-gray-200">
+          <%= @user.name %>
+        </div>
+        <p class="text-xs text-gray-500 mt-1">Username cannot be changed</p>
+      </div>
+
+      <%= form_with model: @user, url: update_profile_settings_path, method: :patch, class: "space-y-4" do |f| %>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
+          <%= f.email_field :email_address, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <% if @user.errors[:email_address].any? %>
+            <p class="text-xs text-red-600 mt-1"><%= @user.errors[:email_address].first %></p>
+          <% end %>
+        </div>
+
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm">
+          Update Email
+        </button>
+      <% end %>
+    </div>
+  </div>
+
+  <%# ── Change Password Section ── %>
+  <div class="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Change Password</h2>
+
+    <%= form_with url: update_password_settings_path, method: :patch, class: "space-y-4" do |f| %>
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Current Password</label>
+        <%= password_field_tag :current_password, nil, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">New Password</label>
+        <%= password_field_tag "user[password]", nil, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Confirm New Password</label>
+        <%= password_field_tag "user[password_confirmation]", nil, class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+      </div>
+
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm">
+        Change Password
+      </button>
+    <% end %>
+  </div>
+
+  <%# ── Tailscale Section ── %>
+  <div class="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Tailscale</h2>
+
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <div>
+          <p class="text-sm font-medium text-gray-700">Status</p>
+          <p class="text-sm text-gray-600">
+            <% case @user.tailscale_state %>
+            <% when "enabled" %>
+              <span class="inline-flex items-center gap-1.5">
+                <span class="w-2 h-2 rounded-full bg-green-500"></span>
+                Enabled
+              </span>
+            <% when "pending" %>
+              <span class="inline-flex items-center gap-1.5">
+                <span class="w-2 h-2 rounded-full bg-yellow-500"></span>
+                Pending authentication
+              </span>
+            <% else %>
+              <span class="inline-flex items-center gap-1.5">
+                <span class="w-2 h-2 rounded-full bg-gray-400"></span>
+                Disabled
+              </span>
+            <% end %>
+          </p>
+        </div>
+        <% if @user.tailscale_enabled? %>
+          <%= link_to "Manage Tailscale", tailscale_path, class: "text-sm text-blue-600 hover:text-blue-700 underline" %>
+        <% end %>
+      </div>
+
+      <% if @user.tailscale_enabled? %>
+        <%= form_with url: toggle_tailscale_settings_path, method: :patch, class: "flex items-center gap-3" do |f| %>
+          <label class="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input type="checkbox"
+                   <%= "checked" if @user.tailscale_auto_connect %>
+                   onchange="this.form.requestSubmit()"
+                   class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+            Auto-connect new sandboxes to Tailscale
+          </label>
+        <% end %>
+      <% else %>
+        <p class="text-sm text-gray-500">
+          <%= link_to "Enable Tailscale", tailscale_path, class: "text-blue-600 hover:text-blue-700 underline" %> to connect your sandboxes to your tailnet.
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <%# ── API Token Section ── %>
+  <div class="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">API Token</h2>
+
+    <% if @api_token %>
+      <div class="space-y-4">
+        <div>
+          <p class="text-sm font-medium text-gray-700 mb-1">Current Token</p>
+          <div class="flex items-center gap-2">
+            <code class="flex-1 bg-gray-50 text-gray-900 px-3 py-2 rounded font-mono text-sm border border-gray-200">
+              <%= @api_token.masked_token %>
+            </code>
+          </div>
+          <p class="text-xs text-gray-500 mt-1">
+            Last used: <%= @api_token.last_used_at ? time_ago_in_words(@api_token.last_used_at) + " ago" : "Never" %>
+          </p>
+        </div>
+
+        <div class="flex gap-3">
+          <%= button_to "Generate New Token", generate_token_settings_path, method: :post,
+                class: "px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm",
+                data: { confirm_message: "This will invalidate your current API token. Any applications using it will stop working. Continue?" } %>
+
+          <%= button_to "Revoke Token", revoke_token_settings_path, method: :delete,
+                class: "px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 text-sm",
+                data: { confirm_message: "This will revoke your API token. Any applications using it will stop working. Continue?" } %>
+        </div>
+      </div>
+    <% else %>
+      <div class="space-y-4">
+        <p class="text-sm text-gray-600">No API token generated yet. Generate one to use the Sandcastle CLI and API.</p>
+
+        <%= button_to "Generate API Token", generate_token_settings_path, method: :post,
+              class: "px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm" %>
+      </div>
+    <% end %>
+
+    <div class="mt-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
+      <p class="text-xs text-blue-800">
+        <strong>Tip:</strong> Use your API token with the Sandcastle CLI by running <code class="bg-blue-100 px-1.5 py-0.5 rounded font-mono">sandcastle config set-token</code>
+      </p>
+    </div>
+  </div>
+
+  <%# ── SSH Keys Section (Future) ── %>
+  <div class="bg-white border border-gray-200 rounded-lg p-6 mb-6 opacity-50 cursor-not-allowed">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">SSH Keys</h2>
+    <p class="text-sm text-gray-500">Coming soon: Manage your SSH keys for sandbox access.</p>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -33,7 +33,7 @@
       <span class="mx-2 h-5 w-px bg-gray-200"></span>
 
       <span class="text-sm text-gray-500"><%= Current.user.name %></span>
-      <%= link_to "Password", change_password_path,
+      <%= link_to "Settings", settings_path,
             class: "text-sm text-gray-400 hover:text-gray-600 transition-colors" %>
       <%= button_to "Log out", session_path, method: :delete,
             class: "text-sm text-gray-400 hover:text-gray-600 transition-colors" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,14 @@ Rails.application.routes.draw do
   get  "auth/failure",            to: "oauth_callbacks#failure"
   resource :change_password, only: [ :show, :update ]
 
+  resource :settings, only: :show do
+    patch :update_profile
+    patch :update_password
+    patch :toggle_tailscale
+    post :generate_token
+    delete :revoke_token
+  end
+
   get  "auth/device",              to: "device_auth#show",     as: :auth_device
   post "auth/device/verify",       to: "device_auth#verify",   as: :auth_device_verify
   get  "auth/device/approve/:id",  to: "device_auth#confirm",  as: :auth_device_confirm


### PR DESCRIPTION
Implements user settings page with profile management, Tailscale configuration, and API token management.

Resolves #19

## Changes
- Create SettingsController with profile, password, Tailscale, and API token management
- Add settings view with all sections
- Add Settings link to navbar
- Update guide page with settings section
- Add tailscale_auto_connect? helper method to User model

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/thieso2/Sandcastle/tree/claude/issue-19-20260213-2057) | [View job run](https://github.com/thieso2/Sandcastle/actions/runs/22002564984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Settings page accessible from the navbar for managing account preferences.
  * Update email address and change password from Settings.
  * Generate, revoke, and view API tokens for CLI authentication with copy-to-clipboard functionality.
  * Configure Tailscale auto-connect settings for new sandboxes.

* **Documentation**
  * Added Settings guide explaining profile management, Tailscale configuration, and API token usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->