### PR TITLE
feat: Add support for alternative hostnames with custom SSL certificates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ SECRET_KEY_BASE=
 # Public hostname of the Sandcastle server
 SANDCASTLE_HOST=sandcastle.rocks
 
+# Alternative hostnames (optional, comma-separated)
+# SANDCASTLE_ALT_HOSTNAMES=sandcastle.internal,sc.local
+
 # Data directory for persistent volumes (default: /data)
 # SANDCASTLE_DATA_DIR=/data

--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -177,6 +177,35 @@ sandcastle create my-dev-v2 --snapshot my-checkpoint</code></pre>
     </div>
   </section>
 
+  <%# ── Custom SSL Certificates ── %>
+  <section class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 mb-3">12. Custom SSL certificates <span class="text-sm font-normal text-gray-500">(advanced)</span></h2>
+    <p class="text-gray-700 mb-3">
+      For internal networks, you can configure alternative hostnames with custom SSL certificates to avoid browser warnings.
+    </p>
+
+    <p class="text-gray-700 mb-3"><strong>Generate certificates with mkcert:</strong></p>
+    <pre class="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-sm leading-relaxed"><code># Install mkcert (macOS example)
+brew install mkcert
+mkcert -install
+
+# Generate certificate for your domains
+mkcert sandcastle.internal sc.local</code></pre>
+
+    <p class="text-gray-700 mb-3 mt-4"><strong>Configure Sandcastle:</strong></p>
+    <p class="text-gray-700 mb-3">Add these variables to your <code class="bg-gray-100 px-1.5 py-0.5 rounded">sandcastle.env</code> before installation:</p>
+    <pre class="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-sm leading-relaxed"><code>SANDCASTLE_ALT_HOSTNAMES=sandcastle.internal,sc.local
+SANDCASTLE_CUSTOM_CERT_PATH=/path/to/sandcastle.internal+1.pem
+SANDCASTLE_CUSTOM_KEY_PATH=/path/to/sandcastle.internal+1-key.pem
+SANDCASTLE_TLS_MODE=selfsigned</code></pre>
+
+    <p class="text-gray-700 mb-3 mt-4">The installer will copy the certificates to <code class="bg-gray-100 px-1.5 py-0.5 rounded">$SANDCASTLE_HOME/data/traefik/certs/</code> and configure Traefik to serve them for the specified hostnames.</p>
+
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mt-4 text-sm text-blue-800">
+      <strong>Note:</strong> You'll need to add DNS entries (or edit <code class="bg-blue-100 px-1 rounded">/etc/hosts</code>) to point your alternative hostnames to the Sandcastle server IP.
+    </div>
+  </section>
+
   <div class="border-t border-gray-200 pt-6 text-center">
     <p class="text-sm text-gray-500">
       Run <code class="bg-gray-100 px-1.5 py-0.5 rounded">sandcastle --help</code> for the full command reference.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       SANDCASTLE_HOST: ${SANDCASTLE_HOST}
       SANDCASTLE_DATA_DIR: /data
       SANDCASTLE_TLS_MODE: ${SANDCASTLE_TLS_MODE:-letsencrypt}
+      SANDCASTLE_ALT_HOSTNAMES: ${SANDCASTLE_ALT_HOSTNAMES:-}
       DB_HOST: postgres
       DB_USER: sandcastle
       DB_PASSWORD: ${DB_PASSWORD:-sandcastle}


### PR DESCRIPTION
Implements support for alternative hostnames with custom SSL certificates for Sandcastle, allowing users to configure custom domain names with valid SSL certificates for internal networks.

## New Environment Variables
- `SANDCASTLE_ALT_HOSTNAMES` - Comma-separated list of alternative domain names
- `SANDCASTLE_CUSTOM_CERT_PATH` - Path to custom certificate file
- `SANDCASTLE_CUSTOM_KEY_PATH` - Path to custom key file

## How It Works
1. Installer copies custom certificates to `$SANDCASTLE_HOME/data/traefik/certs/`
2. RouteManager generates routing rules for all configured hostnames
3. Traefik serves custom certificates for the specified hostnames

## Changes
- Added certificate copying logic to installer
- Updated RouteManager to support multiple hostnames
- Added custom certificate support in Traefik config
- Added section 12 to user guide with mkcert example

Closes #30

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring alternative hostnames in Sandcastle deployments
  * Added support for custom SSL certificates to secure internal hostname connections with advanced certificate management

* **Documentation**
  * New advanced guide on generating and configuring custom SSL certificates using mkcert, setting environment variables, managing certificate files, and updating DNS/hosts configuration for internal hostnames

<!-- end of auto-generated comment: release notes by coderabbit.ai -->