### PR TITLE
feat: add mosh support to sandbox and connect command

### DIFF
--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -78,6 +78,20 @@ sandcastle connect my-dev
 
 # Plain SSH
 sandcastle ssh my-dev</code></pre>
+
+    <h3 class="text-base font-semibold text-gray-800 mt-4 mb-2">Mosh (persistent, roaming sessions)</h3>
+    <p class="text-gray-700 mb-3">
+      Use <a href="https://mosh.org" target="_blank" class="text-blue-600 hover:text-blue-800 underline">mosh</a>
+      for a connection that survives network changes and high-latency links. Mosh is pre-installed in every sandbox.
+    </p>
+    <pre class="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-sm leading-relaxed"><code>sandcastle connect --mosh my-dev</code></pre>
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mt-3 text-sm text-blue-800">
+      <strong>Requirements:</strong> <code class="bg-blue-100 px-1 rounded">mosh</code> must be installed on your local machine
+      (<code class="bg-blue-100 px-1 rounded">brew install mosh</code> on macOS,
+      <code class="bg-blue-100 px-1 rounded">apt install mosh</code> on Debian/Ubuntu).
+      Mosh uses UDP ports 60000–61000 — if your sandbox is reachable only via SSH tunneling, use
+      <a href="#tailscale" class="underline">Tailscale</a> instead (it handles UDP natively).
+    </div>
   </section>
 
   <%# ── Web Terminal ── %>

--- a/images/sandbox/Dockerfile
+++ b/images/sandbox/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     openssh-server sudo curl git tmux vim neovim \
     build-essential \
     jq ripgrep fd-find htop wget unzip ca-certificates net-tools iproute2 iputils-ping \
+    mosh \
     && rm -rf /var/lib/apt/lists/*
 
 # GUI tools: TigerVNC (Xvnc = virtual X server + VNC server combined) and window manager.
@@ -142,5 +143,6 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /workspace
 EXPOSE 22 5900 6080 7681 7682
+EXPOSE 60000-61000/udp
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/vendor/sandcastle-cli/cmd/connect.go
+++ b/vendor/sandcastle-cli/cmd/connect.go
@@ -13,9 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var connectMosh bool
+
 func init() {
 	rootCmd.AddCommand(connectCmd)
 	rootCmd.AddCommand(sshCmd)
+	connectCmd.Flags().BoolVar(&connectMosh, "mosh", false, "Connect using mosh instead of SSH (requires mosh on client)")
 }
 
 var connectCmd = &cobra.Command{
@@ -55,6 +58,10 @@ var connectCmd = &cobra.Command{
 
 		if err := waitForSSH(info.Host, info.Port); err != nil {
 			return err
+		}
+
+		if connectMosh {
+			return moshExec(info.Host, info.Port, info.User, "tmux new-session -A -s main")
 		}
 
 		// SSH with tmux attach-or-create
@@ -163,6 +170,46 @@ func sshExec(host string, port int, user string, remoteCmd string) error {
 	process, err := os.StartProcess(sshPath, append([]string{"ssh"}, sshArgs...), proc)
 	if err != nil {
 		return fmt.Errorf("starting ssh: %w", err)
+	}
+
+	state, err := process.Wait()
+	if err != nil {
+		return err
+	}
+	if !state.Success() {
+		os.Exit(state.ExitCode())
+	}
+	return nil
+}
+
+func moshExec(host string, port int, user string, remoteCmd string) error {
+	moshPath, err := exec.LookPath("mosh")
+	if err != nil {
+		return fmt.Errorf("mosh not found in PATH — install mosh on your local machine first (https://mosh.org)")
+	}
+
+	// Build the SSH options string for mosh --ssh=
+	sshOpts := fmt.Sprintf("ssh -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR", port)
+
+	moshArgs := []string{
+		fmt.Sprintf("--ssh=%s", sshOpts),
+	}
+	if remoteCmd != "" {
+		moshArgs = append(moshArgs, "--", fmt.Sprintf("%s@%s", user, host), remoteCmd)
+	} else {
+		moshArgs = append(moshArgs, fmt.Sprintf("%s@%s", user, host))
+	}
+
+	if os.Getenv("VERBOSE") == "1" {
+		fmt.Fprintf(os.Stderr, "→ mosh %s\n", shellJoin(moshArgs))
+	}
+
+	proc := &os.ProcAttr{
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+	}
+	process, err := os.StartProcess(moshPath, append([]string{"mosh"}, moshArgs...), proc)
+	if err != nil {
+		return fmt.Errorf("starting mosh: %w", err)
 	}
 
 	state, err := process.Wait()


### PR DESCRIPTION
Implements #060

- Install `mosh` in sandbox Dockerfile
- Expose UDP 60000–61000 for mosh connections
- Add `--mosh` flag to `sandcastle connect`
- Friendly error if mosh not found on client
- Guide page updated with mosh usage

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --mosh flag to enable connections using Mosh, providing persistent and roaming sessions as an alternative to SSH.

* **Documentation**
  * Added Mosh documentation including installation requirements for macOS and Debian/Ubuntu, UDP port details (60000-61000), and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->