### PR TITLE
feat(cli): global CLI preferences in config.yaml with ENV var overrides

### DIFF
--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -301,6 +301,35 @@ SANDCASTLE_TLS_MODE=selfsigned</code></pre>
     </div>
   </section>
 
+  <%# ── CLI Preferences ── %>
+  <section class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 mb-3">14. CLI preferences</h2>
+    <p class="text-gray-700 mb-3">
+      Persist connection preferences in <code class="bg-gray-100 px-1 rounded">~/.sandcastle/config.yaml</code>.
+      Environment variables override the file (useful with
+      <code class="bg-gray-100 px-1 rounded">mise</code> or <code class="bg-gray-100 px-1 rounded">direnv</code>).
+    </p>
+    <pre class="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-sm leading-relaxed"><code># Use mosh instead of SSH by default
+sandcastle config set connect_protocol mosh
+
+# Disable automatic tmux session attachment
+sandcastle config set use_tmux false
+
+# Show effective settings (merged from config file + env vars)
+sandcastle config show</code></pre>
+
+    <p class="text-gray-700 mb-2 mt-4">Environment variable overrides (highest priority):</p>
+    <pre class="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-sm leading-relaxed"><code>SANDCASTLE_CONNECT_PROTOCOL=mosh  # "ssh" (default) | "mosh"
+SANDCASTLE_USE_TMUX=false         # "true" (default) | "false"
+SANDCASTLE_SSH_EXTRA_ARGS="-v"   # extra flags appended to ssh/mosh</code></pre>
+
+    <p class="text-gray-700 mb-2 mt-4">Example: per-project override with mise:</p>
+    <pre class="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-sm leading-relaxed"><code># .mise.toml
+[env]
+SANDCASTLE_CONNECT_PROTOCOL = "mosh"
+SANDCASTLE_USE_TMUX = "false"</code></pre>
+  </section>
+
   <div class="border-t border-gray-200 pt-6 text-center">
     <p class="text-sm text-gray-500">
       Run <code class="bg-gray-100 px-1.5 py-0.5 rounded">sandcastle --help</code> for the full command reference.

--- a/vendor/sandcastle-cli/cmd/config.go
+++ b/vendor/sandcastle-cli/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/sandcastle/cli/internal/config"
@@ -11,6 +12,7 @@ import (
 func init() {
 	rootCmd.AddCommand(configCmd)
 	configCmd.AddCommand(showConfigCmd)
+	configCmd.AddCommand(configSetCmd)
 
 	rootCmd.AddCommand(serverCmd)
 	serverCmd.AddCommand(serverListCmd)
@@ -55,6 +57,83 @@ var showConfigCmd = &cobra.Command{
 			fmt.Println("Token:  (not set)")
 		}
 		fmt.Printf("Config: %s\n", config.Path())
+
+		// Show effective preferences with source annotation
+		prefs := cfg.LoadPreferences()
+		fmt.Println()
+		fmt.Println("Preferences (effective):")
+
+		protocolSrc := sourceLabel(
+			os.Getenv("SANDCASTLE_CONNECT_PROTOCOL") != "",
+			cfg.Preferences.ConnectProtocol != "",
+		)
+		fmt.Printf("  connect_protocol: %-6s  [%s]\n", prefs.ConnectProtocol, protocolSrc)
+
+		useTmuxVal := "true"
+		if prefs.UseTmux != nil && !*prefs.UseTmux {
+			useTmuxVal = "false"
+		}
+		tmuxSrc := sourceLabel(
+			os.Getenv("SANDCASTLE_USE_TMUX") != "",
+			cfg.Preferences.UseTmux != nil,
+		)
+		fmt.Printf("  use_tmux:         %-6s  [%s]\n", useTmuxVal, tmuxSrc)
+
+		extraArgs := prefs.SSHExtraArgs
+		if extraArgs == "" {
+			extraArgs = "(not set)"
+		}
+		extraArgsSrc := sourceLabel(
+			os.Getenv("SANDCASTLE_SSH_EXTRA_ARGS") != "",
+			cfg.Preferences.SSHExtraArgs != "",
+		)
+		fmt.Printf("  ssh_extra_args:   %s  [%s]\n", extraArgs, extraArgsSrc)
+
+		return nil
+	},
+}
+
+// sourceLabel returns "env", "config", or "default" to annotate where a value comes from.
+func sourceLabel(fromEnv, fromConfig bool) string {
+	if fromEnv {
+		return "env"
+	}
+	if fromConfig {
+		return "config"
+	}
+	return "default"
+}
+
+var configSetCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a CLI preference",
+	Long: `Set a CLI preference and save it to ~/.sandcastle/config.yaml.
+
+Valid keys:
+  connect_protocol   Connection protocol: "ssh" (default) or "mosh"
+  use_tmux           Wrap connection in tmux: "true" (default) or "false"
+  ssh_extra_args     Extra flags appended to the ssh/mosh invocation
+
+ENV vars override config file values at runtime:
+  SANDCASTLE_CONNECT_PROTOCOL, SANDCASTLE_USE_TMUX, SANDCASTLE_SSH_EXTRA_ARGS`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key, value := args[0], args[1]
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+
+		if err := cfg.SetPreference(key, value); err != nil {
+			return err
+		}
+
+		if err := config.Save(cfg); err != nil {
+			return err
+		}
+
+		fmt.Printf("Set %s = %s\n", key, value)
 		return nil
 	},
 }
@@ -67,8 +146,8 @@ var serverCmd = &cobra.Command{
 }
 
 var serverListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List configured servers",
+	Use:     "list",
+	Short:   "List configured servers",
 	Aliases: []string{"ls"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.Load()
@@ -132,10 +211,10 @@ var serverUseCmd = &cobra.Command{
 }
 
 var serverRemoveCmd = &cobra.Command{
-	Use:   "remove <alias>",
-	Short: "Remove a configured server",
+	Use:     "remove <alias>",
+	Short:   "Remove a configured server",
 	Aliases: []string{"rm"},
-	Args:  cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		alias := args[0]
 		cfg, err := config.Load()
@@ -165,4 +244,3 @@ var serverRemoveCmd = &cobra.Command{
 		return nil
 	},
 }
-

--- a/vendor/sandcastle-cli/cmd/connect.go
+++ b/vendor/sandcastle-cli/cmd/connect.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sandcastle/cli/api"
+	"github.com/sandcastle/cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,7 @@ func init() {
 
 var connectCmd = &cobra.Command{
 	Use:   "connect [name]",
-	Short: "SSH into sandbox and attach tmux (auto-starts if stopped)",
+	Short: "Connect to sandbox and attach tmux (auto-starts if stopped)",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := resolveSandboxName(args)
@@ -60,12 +61,22 @@ var connectCmd = &cobra.Command{
 			return err
 		}
 
-		if connectMosh {
-			return moshExec(info.Host, info.Port, info.User, "tmux new-session -A -s main")
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		prefs := cfg.LoadPreferences()
+
+		var remoteCmd string
+		if *prefs.UseTmux {
+			remoteCmd = "tmux new-session -A -s main"
 		}
 
-		// SSH with tmux attach-or-create
-		return sshExec(info.Host, info.Port, info.User, "tmux new-session -A -s main")
+		// --mosh flag takes precedence over ConnectProtocol preference
+		if connectMosh || prefs.ConnectProtocol == "mosh" {
+			return moshExec(info.Host, info.Port, info.User, remoteCmd, prefs.SSHExtraArgs)
+		}
+		return sshExec(info.Host, info.Port, info.User, remoteCmd, prefs.SSHExtraArgs)
 	},
 }
 
@@ -99,7 +110,13 @@ var sshCmd = &cobra.Command{
 			return err
 		}
 
-		return sshExec(info.Host, info.Port, info.User, "")
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		prefs := cfg.LoadPreferences()
+
+		return sshExec(info.Host, info.Port, info.User, "", prefs.SSHExtraArgs)
 	},
 }
 
@@ -143,14 +160,17 @@ func waitForSSH(host string, port int) error {
 	return fmt.Errorf("timeout waiting for SSH at %s", addr)
 }
 
-func sshExec(host string, port int, user string, remoteCmd string) error {
+func sshExec(host string, port int, user string, remoteCmd string, extraArgs string) error {
 	sshArgs := []string{
 		"-p", strconv.Itoa(port),
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "LogLevel=ERROR",
-		fmt.Sprintf("%s@%s", user, host),
 	}
+	if extraArgs != "" {
+		sshArgs = append(sshArgs, strings.Fields(extraArgs)...)
+	}
+	sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host))
 	if remoteCmd != "" {
 		sshArgs = append(sshArgs, "-t", remoteCmd)
 	}
@@ -182,22 +202,24 @@ func sshExec(host string, port int, user string, remoteCmd string) error {
 	return nil
 }
 
-func moshExec(host string, port int, user string, remoteCmd string) error {
-	moshPath, err := exec.LookPath("mosh")
-	if err != nil {
-		return fmt.Errorf("mosh not found in PATH — install mosh on your local machine first (https://mosh.org)")
-	}
-
-	// Build the SSH options string for mosh --ssh=
+func moshExec(host string, port int, user string, remoteCmd string, extraArgs string) error {
 	sshOpts := fmt.Sprintf("ssh -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR", port)
+	if extraArgs != "" {
+		sshOpts += " " + extraArgs
+	}
 
 	moshArgs := []string{
-		fmt.Sprintf("--ssh=%s", sshOpts),
+		"--ssh=" + sshOpts,
+		fmt.Sprintf("%s@%s", user, host),
 	}
 	if remoteCmd != "" {
-		moshArgs = append(moshArgs, "--", fmt.Sprintf("%s@%s", user, host), remoteCmd)
-	} else {
-		moshArgs = append(moshArgs, fmt.Sprintf("%s@%s", user, host))
+		moshArgs = append(moshArgs, "--")
+		moshArgs = append(moshArgs, strings.Fields(remoteCmd)...)
+	}
+
+	moshPath, err := exec.LookPath("mosh")
+	if err != nil {
+		return fmt.Errorf("mosh not found in PATH — install mosh on your local machine first (https://mosh.org): %w", err)
 	}
 
 	if os.Getenv("VERBOSE") == "1" {

--- a/vendor/sandcastle-cli/cmd/exec.go
+++ b/vendor/sandcastle-cli/cmd/exec.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sandcastle/cli/api"
+	"github.com/sandcastle/cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,12 @@ var execCmd = &cobra.Command{
 			return err
 		}
 
-		return sshExec(info.Host, info.Port, info.User, remoteCmd)
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		prefs := cfg.LoadPreferences()
+
+		return sshExec(info.Host, info.Port, info.User, remoteCmd, prefs.SSHExtraArgs)
 	},
 }

--- a/vendor/sandcastle-cli/cmd/sandbox.go
+++ b/vendor/sandcastle-cli/cmd/sandbox.go
@@ -201,7 +201,23 @@ Flags explicitly passed on the command line take precedence over environment var
 			return err
 		}
 
-		sshErr := sshExec(info.Host, info.Port, info.User, "tmux new-session -A -s main")
+		cfg, loadErr := config.Load()
+		if loadErr != nil {
+			return loadErr
+		}
+		prefs := cfg.LoadPreferences()
+
+		var remoteCmd string
+		if *prefs.UseTmux {
+			remoteCmd = "tmux new-session -A -s main"
+		}
+
+		var sshErr error
+		if prefs.ConnectProtocol == "mosh" {
+			sshErr = moshExec(info.Host, info.Port, info.User, remoteCmd, prefs.SSHExtraArgs)
+		} else {
+			sshErr = sshExec(info.Host, info.Port, info.User, remoteCmd, prefs.SSHExtraArgs)
+		}
 
 		if sandboxRemove {
 			// Re-fetch to check if user toggled to "keep" during the session

--- a/vendor/sandcastle-cli/internal/config/config.go
+++ b/vendor/sandcastle-cli/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -14,9 +15,18 @@ type ServerConfig struct {
 	Insecure bool   `yaml:"insecure,omitempty"`
 }
 
+// Preferences holds user-configurable CLI behaviour. Each field can be
+// overridden by a SANDCASTLE_<KEY> environment variable at runtime.
+type Preferences struct {
+	ConnectProtocol string `yaml:"connect_protocol,omitempty"` // "ssh" (default) | "mosh"
+	UseTmux         *bool  `yaml:"use_tmux,omitempty"`         // default true
+	SSHExtraArgs    string `yaml:"ssh_extra_args,omitempty"`   // extra flags for ssh/mosh
+}
+
 type Config struct {
 	CurrentServer string                  `yaml:"current_server"`
 	Servers       map[string]ServerConfig `yaml:"servers"`
+	Preferences   Preferences             `yaml:"preferences,omitempty"`
 }
 
 // legacyConfig is the old flat format for migration.
@@ -102,5 +112,60 @@ func (c *Config) SetServer(alias, url, token string, insecure bool) {
 	}
 	c.Servers[alias] = ServerConfig{URL: url, Token: token, Insecure: insecure}
 	c.CurrentServer = alias
+}
+
+// LoadPreferences returns effective preferences with env vars overlaid.
+// Priority: ENV var > config file preference > built-in default.
+func (c *Config) LoadPreferences() Preferences {
+	p := c.Preferences
+
+	if v := os.Getenv("SANDCASTLE_CONNECT_PROTOCOL"); v != "" {
+		p.ConnectProtocol = v
+	}
+	if v := os.Getenv("SANDCASTLE_USE_TMUX"); v != "" {
+		b := strings.ToLower(v) == "true" || v == "1"
+		p.UseTmux = &b
+	}
+	if v := os.Getenv("SANDCASTLE_SSH_EXTRA_ARGS"); v != "" {
+		p.SSHExtraArgs = v
+	}
+
+	// Apply built-in defaults
+	if p.ConnectProtocol == "" {
+		p.ConnectProtocol = "ssh"
+	}
+	if p.UseTmux == nil {
+		t := true
+		p.UseTmux = &t
+	}
+
+	return p
+}
+
+// SetPreference sets a named preference by string value and validates it.
+func (c *Config) SetPreference(key, value string) error {
+	switch key {
+	case "connect_protocol":
+		if value != "ssh" && value != "mosh" {
+			return fmt.Errorf("connect_protocol must be 'ssh' or 'mosh', got %q", value)
+		}
+		c.Preferences.ConnectProtocol = value
+	case "use_tmux":
+		switch strings.ToLower(value) {
+		case "true", "1", "yes":
+			t := true
+			c.Preferences.UseTmux = &t
+		case "false", "0", "no":
+			f := false
+			c.Preferences.UseTmux = &f
+		default:
+			return fmt.Errorf("use_tmux must be 'true' or 'false', got %q", value)
+		}
+	case "ssh_extra_args":
+		c.Preferences.SSHExtraArgs = value
+	default:
+		return fmt.Errorf("unknown preference %q; valid keys: connect_protocol, use_tmux, ssh_extra_args", key)
+	}
+	return nil
 }
 


### PR DESCRIPTION
Implements # 62 - global CLI preferences in config.yaml with ENV var overrides.

Adds a `preferences` section to `~/.sandcastle/config.yaml` so users can persist connection defaults. Each preference can be overridden by a `SANDCASTLE_<KEY>` env var (useful with mise/direnv).

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent CLI preferences: connect protocol, tmux usage, and extra SSH args with env overrides and per-project settings.
  * Added a "config set" command to save preferences.
  * Mosh added as an alternative connection protocol; effective preference is shown and applied.
  * "config show" now annotates where each preference came from (env, config, default).

* **Documentation**
  * New guide section with examples for setting, viewing, and per-project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->