### PR TITLE
feat: full-instance backup/restore with --from-backup install option

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -49,7 +49,7 @@ esac
 
 if [ "$COMMAND" = "help" ]; then
   cat <<'USAGE'
-Usage: installer.sh [COMMAND]
+Usage: installer.sh [COMMAND] [OPTIONS]
 
 Sandcastle installer — sets up Docker (via Dockyard), Traefik, and the
 Sandcastle platform.
@@ -62,15 +62,27 @@ Commands:
   uninstall    Remove Sandcastle completely
   help         Show this help message
 
+install options:
+  --from-backup <file>   Restore data from a backup file after installing.
+                         Secrets, database, and user data are loaded from the
+                         backup instead of being generated fresh.
+                         SANDCASTLE_HOST is still required in sandcastle.env.
+                         SANDCASTLE_ADMIN_EMAIL/PASSWORD are not required.
+
 Environment:
   SANDCASTLE_ENV   Path to config file (default search order:
                    ./sandcastle.env → <script_dir>/sandcastle.env →
                    $SANDCASTLE_HOME/etc/sandcastle.env)
 
-Workflow:
+Workflow (fresh install):
   1. installer.sh gen-env              # generate config
   2. vi sandcastle.env                 # edit to taste
   3. sudo installer.sh install         # install (finds ./sandcastle.env)
+
+Workflow (restore from backup):
+  1. installer.sh gen-env              # generate config (set SANDCASTLE_HOST)
+  2. vi sandcastle.env                 # set host, TLS mode — no admin password needed
+  3. sudo installer.sh install --from-backup ./sandcastle-backup-*.tar.zst
 USAGE
   exit 0
 fi
@@ -208,7 +220,7 @@ setup_passwordless_sudo() {
 setup_bashrc_path() {
   local profile="${SANDCASTLE_HOME}/.profile"
   local bashrc="${SANDCASTLE_HOME}/.bashrc"
-  local path_export="export PATH=${SANDCASTLE_HOME}/docker-runtime/bin:\$PATH"
+  local path_export="export PATH=${SANDCASTLE_HOME}/docker-runtime/bin:${SANDCASTLE_HOME}/bin:\$PATH"
 
   info "Configuring PATH in .profile and .bashrc..."
 
@@ -231,6 +243,570 @@ setup_bashrc_path() {
   fi
 
   ok "PATH configured in .profile and .bashrc"
+}
+
+# ═══ install_prerequisites ════════════════════════════════════════════════════
+# Install required host tools: zstd (for backup/restore), rsync (for data copy)
+
+install_prerequisites() {
+  local missing=()
+  command -v zstd >/dev/null 2>&1  || missing+=("zstd")
+  command -v rsync >/dev/null 2>&1 || missing+=("rsync")
+  if [ ${#missing[@]} -gt 0 ]; then
+    info "Installing prerequisites: ${missing[*]}..."
+    apt-get install -y "${missing[@]}" >/dev/null 2>&1 \
+      || warn "Failed to install ${missing[*]} — backup/restore may not work"
+    ok "Prerequisites installed: ${missing[*]}"
+  fi
+}
+
+# ═══ write_admin_script ═══════════════════════════════════════════════════════
+# Install sandcastle-admin to $SANDCASTLE_HOME/bin/
+
+write_admin_script() {
+  local bin_dir="$SANDCASTLE_HOME/bin"
+  mkdir -p "$bin_dir"
+
+  cat > "$bin_dir/sandcastle-admin" <<'__ADMIN_EOF__'
+#!/bin/bash
+# sandcastle-admin — Sandcastle backup/restore administration tool
+# Usage: sandcastle-admin <command> [options]
+set -euo pipefail
+
+# ═══ Colors & helpers ════════════════════════════════════════════════════════
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+die()   { error "$@"; exit 1; }
+
+# ═══ Config ══════════════════════════════════════════════════════════════════
+
+SANDCASTLE_HOME="${SANDCASTLE_HOME:-/sandcastle}"
+
+# Load installed env
+ENV_FILE="$SANDCASTLE_HOME/etc/sandcastle.env"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+fi
+
+DOCKYARD_ROOT="${DOCKYARD_ROOT:-$SANDCASTLE_HOME}"
+DOCKER="${DOCKYARD_ROOT}/docker-runtime/bin/docker"
+COMPOSE_FILE="$SANDCASTLE_HOME/docker-compose.yml"
+
+[ -x "$DOCKER" ] || die "Docker not found at $DOCKER — is Sandcastle installed?"
+[ -f "$COMPOSE_FILE" ] || die "docker-compose.yml not found at $COMPOSE_FILE — is Sandcastle installed?"
+
+# ═══ BTRFS helpers ═══════════════════════════════════════════════════════════
+
+is_btrfs() {
+  stat -f --format="%T" "$1" 2>/dev/null | grep -qi btrfs
+}
+
+btrfs_snapshot_r() {
+  btrfs subvolume snapshot -r "$1" "$2" 2>/dev/null
+}
+
+btrfs_delete() {
+  btrfs subvolume delete "$1" 2>/dev/null || rm -rf "$1"
+}
+
+# ═══ cmd_backup ══════════════════════════════════════════════════════════════
+
+cmd_backup() {
+  local output=""
+  local skip_sandbox_volumes=false
+  local skip_snapshot_images=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --output|-o)
+        output="$2"
+        shift 2
+        ;;
+      --no-sandbox-volumes)
+        skip_sandbox_volumes=true
+        shift
+        ;;
+      --no-snapshot-images)
+        skip_snapshot_images=true
+        shift
+        ;;
+      *)
+        die "Unknown option: $1 (run 'sandcastle-admin help' for usage)"
+        ;;
+    esac
+  done
+
+  command -v zstd >/dev/null 2>&1 || die "zstd not found — install: apt-get install zstd"
+  command -v rsync >/dev/null 2>&1 || die "rsync not found — install: apt-get install rsync"
+
+  # Get app version from the running web container (fall back gracefully)
+  local version
+  version=$($DOCKER compose -f "$COMPOSE_FILE" exec -T web \
+    ./bin/rails runner "puts Sandcastle::VERSION rescue puts '0.0.0'" 2>/dev/null \
+    | tail -1 || echo "unknown")
+  version="${version:-unknown}"
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%d_%H%M%S")
+  local default_output="./sandcastle-backup-${timestamp}-${version}.tar.zst"
+  output="${output:-$default_output}"
+
+  local work_dir
+  work_dir=$(mktemp -d)
+  trap 'rm -rf "$work_dir"' EXIT
+
+  local backup_dir="$work_dir/sandcastle-backup"
+  mkdir -p "$backup_dir"/{db,secrets,data}
+
+  echo ""
+  echo -e "${BLUE}═══ Sandcastle Backup ═══${NC}"
+  echo ""
+  info "Output: $output"
+  echo ""
+
+  # ── Dump PostgreSQL databases ─────────────────────────────────────────────
+
+  info "Dumping PostgreSQL databases..."
+  local db
+  for db in sandcastle_production sandcastle_production_cache sandcastle_production_queue sandcastle_production_cable; do
+    info "  pg_dump $db..."
+    $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+      pg_dump -U sandcastle --format=custom "$db" \
+      > "$backup_dir/db/${db}.pgdump"
+    ok "  ${db}.pgdump"
+  done
+
+  # ── Secrets ───────────────────────────────────────────────────────────────
+
+  info "Backing up secrets..."
+  local rails_secrets="$SANDCASTLE_HOME/data/rails/.secrets"
+  local postgres_secrets="$SANDCASTLE_HOME/data/postgres/.secrets"
+
+  if [ -f "$rails_secrets" ]; then
+    cp "$rails_secrets" "$backup_dir/secrets/rails.secrets"
+    ok "  rails.secrets"
+  else
+    warn "  Rails secrets not found at $rails_secrets"
+  fi
+
+  if [ -f "$postgres_secrets" ]; then
+    cp "$postgres_secrets" "$backup_dir/secrets/postgres.secrets"
+    ok "  postgres.secrets"
+  else
+    warn "  Postgres secrets not found at $postgres_secrets"
+  fi
+
+  # Let's Encrypt cert (nice-to-have)
+  local acme_json="$SANDCASTLE_HOME/data/traefik/acme.json"
+  if [ -f "$acme_json" ] && [ -s "$acme_json" ]; then
+    cp "$acme_json" "$backup_dir/secrets/acme.json"
+    ok "  acme.json"
+  fi
+
+  # ── User data ─────────────────────────────────────────────────────────────
+
+  info "Backing up user data..."
+  mkdir -p "$backup_dir/data/users"
+  if [ -d "$SANDCASTLE_HOME/data/users" ]; then
+    if is_btrfs "$SANDCASTLE_HOME/data/users"; then
+      local snap_users="$SANDCASTLE_HOME/data/.backup-snap-users-$$"
+      btrfs_snapshot_r "$SANDCASTLE_HOME/data/users" "$snap_users"
+      rsync -a --exclude='*/home/.docker' "$snap_users/" "$backup_dir/data/users/"
+      btrfs_delete "$snap_users"
+    else
+      rsync -a --exclude='*/home/.docker' "$SANDCASTLE_HOME/data/users/" "$backup_dir/data/users/"
+    fi
+    ok "  users/"
+  fi
+
+  # ── Sandbox volumes ───────────────────────────────────────────────────────
+
+  if [ "$skip_sandbox_volumes" = false ]; then
+    info "Backing up sandbox volumes..."
+    mkdir -p "$backup_dir/data/sandboxes"
+    if [ -d "$SANDCASTLE_HOME/data/sandboxes" ]; then
+      if is_btrfs "$SANDCASTLE_HOME/data/sandboxes"; then
+        local snap_sandboxes="$SANDCASTLE_HOME/data/.backup-snap-sandboxes-$$"
+        btrfs_snapshot_r "$SANDCASTLE_HOME/data/sandboxes" "$snap_sandboxes"
+        rsync -a "$snap_sandboxes/" "$backup_dir/data/sandboxes/"
+        btrfs_delete "$snap_sandboxes"
+      else
+        rsync -a "$SANDCASTLE_HOME/data/sandboxes/" "$backup_dir/data/sandboxes/"
+      fi
+      ok "  sandboxes/"
+    fi
+  else
+    info "Skipping sandbox volumes (--no-sandbox-volumes)"
+  fi
+
+  # ── Snapshot dirs ─────────────────────────────────────────────────────────
+
+  if [ -d "$SANDCASTLE_HOME/data/snapshots" ]; then
+    info "Backing up snapshot directories..."
+    mkdir -p "$backup_dir/data/snapshots"
+    rsync -a "$SANDCASTLE_HOME/data/snapshots/" "$backup_dir/data/snapshots/"
+    ok "  snapshots/"
+  fi
+
+  # ── Snapshot Docker images ────────────────────────────────────────────────
+
+  if [ "$skip_snapshot_images" = false ]; then
+    local snap_images
+    snap_images=$($DOCKER images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+      | grep '^sc-snap-' || true)
+    if [ -n "$snap_images" ]; then
+      info "Saving snapshot Docker images..."
+      mkdir -p "$backup_dir/images"
+      local img fname
+      while IFS= read -r img; do
+        fname=$(echo "$img" | tr '/:' '-').tar
+        info "  docker save $img..."
+        $DOCKER save "$img" > "$backup_dir/images/$fname"
+        ok "  $fname"
+      done <<< "$snap_images"
+    fi
+  else
+    info "Skipping snapshot images (--no-snapshot-images)"
+  fi
+
+  # ── Manifest ──────────────────────────────────────────────────────────────
+
+  local user_count sandbox_count snapshot_count
+  user_count=$(find "$SANDCASTLE_HOME/data/users" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l || echo 0)
+  sandbox_count=$(find "$SANDCASTLE_HOME/data/sandboxes" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l || echo 0)
+  snapshot_count=$(find "$SANDCASTLE_HOME/data/snapshots" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l || echo 0)
+
+  local includes='"db","secrets","user_data"'
+  [ "$skip_sandbox_volumes" = false ] && includes="$includes,\"sandbox_volumes\""
+  [ -d "$SANDCASTLE_HOME/data/snapshots" ] && includes="$includes,\"snapshot_dirs\""
+  [ "$skip_snapshot_images" = false ] && includes="$includes,\"snapshot_images\""
+
+  cat > "$backup_dir/manifest.json" <<MANIFEST
+{
+  "version": "${version}",
+  "schema_version": 1,
+  "created_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "hostname": "$(hostname)",
+  "includes": [${includes}],
+  "user_count": ${user_count},
+  "sandbox_count": ${sandbox_count},
+  "snapshot_count": ${snapshot_count}
+}
+MANIFEST
+
+  # ── Create archive ────────────────────────────────────────────────────────
+
+  info "Creating archive..."
+  tar --use-compress-program=zstd -cf "$output" -C "$work_dir" sandcastle-backup
+
+  local size
+  size=$(du -sh "$output" 2>/dev/null | cut -f1 || echo "?")
+
+  echo ""
+  ok "Backup complete: $output (${size})"
+  echo ""
+}
+
+# ═══ cmd_restore ══════════════════════════════════════════════════════════════
+
+cmd_restore() {
+  local backup_file=""
+  local skip_db=false
+  local skip_data=false
+  local skip_images=false
+  local yes=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --skip-db)     skip_db=true; shift ;;
+      --skip-data)   skip_data=true; shift ;;
+      --skip-images) skip_images=true; shift ;;
+      --yes|-y)      yes=true; shift ;;
+      -*)            die "Unknown option: $1 (run 'sandcastle-admin help' for usage)" ;;
+      *)             backup_file="$1"; shift ;;
+    esac
+  done
+
+  [ -n "$backup_file" ] || die "Usage: sandcastle-admin restore <backup-file.tar.zst> [options]"
+  [ -f "$backup_file" ] || die "Backup file not found: $backup_file"
+
+  command -v zstd >/dev/null 2>&1 || die "zstd not found — install: apt-get install zstd"
+
+  # ── Read and validate manifest ────────────────────────────────────────────
+
+  local work_dir
+  work_dir=$(mktemp -d)
+  trap 'rm -rf "$work_dir"' EXIT
+
+  info "Reading backup manifest..."
+  tar --use-compress-program=zstd -xf "$backup_file" -C "$work_dir" \
+    sandcastle-backup/manifest.json 2>/dev/null \
+    || die "Cannot read manifest — is this a valid Sandcastle backup file?"
+
+  local manifest="$work_dir/sandcastle-backup/manifest.json"
+
+  # Parse with python3 (always available on Ubuntu)
+  local bk_version bk_created bk_hostname bk_schema bk_users bk_sandboxes bk_snapshots
+  bk_version=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('version','?'))")
+  bk_created=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('created_at','?'))")
+  bk_hostname=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('hostname','?'))")
+  bk_schema=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('schema_version',1))")
+  bk_users=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('user_count',0))")
+  bk_sandboxes=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('sandbox_count',0))")
+  bk_snapshots=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('snapshot_count',0))")
+
+  if [ "${bk_schema}" -gt 1 ] 2>/dev/null; then
+    warn "Backup schema_version=${bk_schema} is newer than supported (1) — proceeding anyway"
+  fi
+
+  echo ""
+  echo -e "${BLUE}═══ Sandcastle Restore ═══${NC}"
+  echo ""
+  echo -e "  Backup version:  ${YELLOW}${bk_version}${NC}"
+  echo -e "  Created:         ${bk_created}"
+  echo -e "  Source host:     ${bk_hostname}"
+  echo -e "  Users:           ${bk_users}"
+  echo -e "  Sandboxes:       ${bk_sandboxes}"
+  echo -e "  Snapshots:       ${bk_snapshots}"
+  echo ""
+  echo -e "${YELLOW}WARNING: This will overwrite all current Sandcastle data!${NC}"
+  echo ""
+
+  if [ "$yes" != true ]; then
+    read -rp "Type 'yes' to confirm: " CONFIRM
+    [ "$CONFIRM" = "yes" ] || die "Aborted"
+  fi
+
+  # ── Step 1: Stop Sandcastle ───────────────────────────────────────────────
+
+  info "Step 1/7: Stopping Sandcastle..."
+  cd "$SANDCASTLE_HOME"
+  $DOCKER compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+  ok "Services stopped"
+
+  # ── Extract backup archive ────────────────────────────────────────────────
+
+  info "Extracting backup archive..."
+  tar --use-compress-program=zstd -xf "$backup_file" -C "$work_dir"
+  local bk_dir="$work_dir/sandcastle-backup"
+
+  # ── Step 2: Restore secrets ───────────────────────────────────────────────
+
+  info "Step 2/7: Restoring secrets..."
+
+  local main_env="$SANDCASTLE_HOME/.env"
+
+  if [ -f "$bk_dir/secrets/rails.secrets" ]; then
+    mkdir -p "$SANDCASTLE_HOME/data/rails"
+    cp "$bk_dir/secrets/rails.secrets" "$SANDCASTLE_HOME/data/rails/.secrets"
+    chmod 600 "$SANDCASTLE_HOME/data/rails/.secrets"
+    # Inject AR keys into .env
+    set -a
+    # shellcheck source=/dev/null
+    source "$bk_dir/secrets/rails.secrets"
+    set +a
+    local key val
+    for key in AR_ENCRYPTION_PRIMARY_KEY AR_ENCRYPTION_DETERMINISTIC_KEY AR_ENCRYPTION_KEY_DERIVATION_SALT; do
+      val="${!key:-}"
+      if [ -n "$val" ]; then
+        if grep -q "^${key}=" "$main_env" 2>/dev/null; then
+          sed -i "s|^${key}=.*|${key}=${val}|" "$main_env"
+        else
+          echo "${key}=${val}" >> "$main_env"
+        fi
+      fi
+    done
+    ok "  rails.secrets"
+  fi
+
+  if [ -f "$bk_dir/secrets/postgres.secrets" ]; then
+    mkdir -p "$SANDCASTLE_HOME/data/postgres"
+    cp "$bk_dir/secrets/postgres.secrets" "$SANDCASTLE_HOME/data/postgres/.secrets"
+    chmod 600 "$SANDCASTLE_HOME/data/postgres/.secrets"
+    set -a
+    # shellcheck source=/dev/null
+    source "$bk_dir/secrets/postgres.secrets"
+    set +a
+    if [ -n "${DB_PASSWORD:-}" ]; then
+      if grep -q "^DB_PASSWORD=" "$main_env" 2>/dev/null; then
+        sed -i "s|^DB_PASSWORD=.*|DB_PASSWORD=${DB_PASSWORD}|" "$main_env"
+      else
+        echo "DB_PASSWORD=${DB_PASSWORD}" >> "$main_env"
+      fi
+    fi
+    ok "  postgres.secrets"
+  fi
+
+  if [ -f "$bk_dir/secrets/acme.json" ]; then
+    mkdir -p "$SANDCASTLE_HOME/data/traefik"
+    cp "$bk_dir/secrets/acme.json" "$SANDCASTLE_HOME/data/traefik/acme.json"
+    chmod 600 "$SANDCASTLE_HOME/data/traefik/acme.json"
+    ok "  acme.json"
+  fi
+
+  # Reload .env so subsequent docker compose picks up updated secrets
+  set -a
+  # shellcheck source=/dev/null
+  source "$main_env"
+  set +a
+
+  # ── Step 3 & 4: Database restore ──────────────────────────────────────────
+
+  if [ "$skip_db" = false ]; then
+    info "Step 3/7: Starting PostgreSQL..."
+    $DOCKER compose -f "$COMPOSE_FILE" up -d postgres
+    local i
+    for i in $(seq 1 30); do
+      $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+        pg_isready -U sandcastle -d sandcastle_production &>/dev/null && break
+      sleep 2
+    done
+    ok "PostgreSQL ready"
+
+    info "Step 4/7: Restoring databases..."
+    local db dump
+    for db in sandcastle_production sandcastle_production_cache sandcastle_production_queue sandcastle_production_cable; do
+      dump="$bk_dir/db/${db}.pgdump"
+      if [ -f "$dump" ]; then
+        info "  Restoring $db..."
+        # Ensure the database exists (for cache/queue/cable on first restore)
+        $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+          psql -U sandcastle -d postgres \
+          -c "SELECT 1 FROM pg_database WHERE datname='${db}'" \
+          | grep -q "1 row" \
+          || $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+               createdb -U sandcastle "$db" 2>/dev/null || true
+        $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+          pg_restore -U sandcastle -d "$db" --clean --if-exists < "$dump" 2>/dev/null || true
+        ok "  $db"
+      else
+        warn "  No dump found for $db — skipping"
+      fi
+    done
+  else
+    info "Step 3/7: Skipping database (--skip-db)"
+    info "Step 4/7: Skipping database (--skip-db)"
+  fi
+
+  # ── Step 5: Run migrations ────────────────────────────────────────────────
+
+  info "Step 5/7: Running migrations..."
+  $DOCKER compose -f "$COMPOSE_FILE" run --rm migrate 2>/dev/null \
+    || warn "Migrate service not available — run 'rails db:migrate' manually if needed"
+  ok "Migrations done"
+
+  # ── Step 6: Restore filesystem data ──────────────────────────────────────
+
+  if [ "$skip_data" = false ]; then
+    info "Step 6/7: Restoring filesystem data..."
+
+    if [ -d "$bk_dir/data/users" ]; then
+      mkdir -p "$SANDCASTLE_HOME/data/users"
+      rsync -a --delete "$bk_dir/data/users/" "$SANDCASTLE_HOME/data/users/"
+      ok "  users/"
+    fi
+
+    if [ -d "$bk_dir/data/sandboxes" ]; then
+      mkdir -p "$SANDCASTLE_HOME/data/sandboxes"
+      rsync -a --delete "$bk_dir/data/sandboxes/" "$SANDCASTLE_HOME/data/sandboxes/"
+      ok "  sandboxes/"
+    fi
+
+    if [ -d "$bk_dir/data/snapshots" ]; then
+      mkdir -p "$SANDCASTLE_HOME/data/snapshots"
+      rsync -a --delete "$bk_dir/data/snapshots/" "$SANDCASTLE_HOME/data/snapshots/"
+      ok "  snapshots/"
+    fi
+  else
+    info "Step 6/7: Skipping filesystem data (--skip-data)"
+  fi
+
+  # ── Step 7: Load snapshot Docker images ───────────────────────────────────
+
+  if [ "$skip_images" = false ] && [ -d "$bk_dir/images" ]; then
+    info "Step 7/7: Loading snapshot Docker images..."
+    local img_tar
+    for img_tar in "$bk_dir/images/"*.tar; do
+      [ -f "$img_tar" ] || continue
+      info "  Loading $(basename "$img_tar")..."
+      $DOCKER load < "$img_tar"
+      ok "  $(basename "$img_tar")"
+    done
+  else
+    info "Step 7/7: Skipping snapshot images"
+  fi
+
+  # ── Start Sandcastle ───────────────────────────────────────────────────────
+
+  info "Starting Sandcastle..."
+  cd "$SANDCASTLE_HOME"
+  $DOCKER compose -f "$COMPOSE_FILE" up -d
+  ok "Sandcastle started"
+
+  echo ""
+  ok "Restore complete!"
+  echo ""
+}
+
+# ═══ Help ════════════════════════════════════════════════════════════════════
+
+cmd_help() {
+  cat <<'USAGE'
+Usage: sandcastle-admin <command> [options]
+
+Commands:
+  backup     Create a full backup of this Sandcastle instance
+  restore    Restore a Sandcastle instance from a backup file
+  help       Show this help message
+
+backup [options]:
+  --output <path>           Output path (default: ./sandcastle-backup-<ts>-<ver>.tar.zst)
+  --no-sandbox-volumes      Skip /data/sandboxes/*/vol (faster/smaller)
+  --no-snapshot-images      Skip docker save of snapshot images
+
+restore <file.tar.zst> [options]:
+  --skip-db                 Skip database restore
+  --skip-data               Skip filesystem data restore
+  --skip-images             Skip loading snapshot Docker images
+  --yes, -y                 Skip confirmation prompt
+
+Examples:
+  sandcastle-admin backup
+  sandcastle-admin backup --output /mnt/backups/sc.tar.zst --no-snapshot-images
+  sandcastle-admin restore /mnt/backups/sandcastle-backup-2026-03-01.tar.zst
+  sandcastle-admin restore /mnt/backups/sc.tar.zst --skip-db --yes
+USAGE
+}
+
+# ═══ Dispatch ════════════════════════════════════════════════════════════════
+
+COMMAND="${1:-help}"
+shift 2>/dev/null || true
+
+case "$COMMAND" in
+  backup)         cmd_backup "$@" ;;
+  restore)        cmd_restore "$@" ;;
+  help|-h|--help) cmd_help ;;
+  *) die "Unknown command: $COMMAND — run 'sandcastle-admin help'" ;;
+esac
+__ADMIN_EOF__
+
+  chmod +x "$bin_dir/sandcastle-admin"
+  chown "${SANDCASTLE_USER}:${SANDCASTLE_GROUP}" "$bin_dir/sandcastle-admin"
+  wrote "$bin_dir/sandcastle-admin"
+  ok "sandcastle-admin installed to $bin_dir"
 }
 
 # ═══ setup_login_banner ══════════════════════════════════════════════════
@@ -2025,6 +2601,22 @@ cmd_destroy() {
 # ═══ cmd_install ═════════════════════════════════════════════════════════════
 
 cmd_install() {
+  # Parse install-specific options
+  local BACKUP_FILE=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --from-backup)
+        BACKUP_FILE="$2"
+        [ -n "$BACKUP_FILE" ] || die "--from-backup requires a backup file path"
+        [ -f "$BACKUP_FILE" ] || die "Backup file not found: $BACKUP_FILE"
+        shift 2
+        ;;
+      *)
+        die "Unknown option for install: $1 (use --from-backup <file>)"
+        ;;
+    esac
+  done
+
   require_root
 
   if ! grep -qi ubuntu /etc/os-release 2>/dev/null; then
@@ -2148,50 +2740,92 @@ DYEOF
 
   if [ "$FRESH_INSTALL" = true ]; then
     [ -z "${SANDCASTLE_HOST:-}" ] && die "SANDCASTLE_HOST is required (set in sandcastle.env)"
-    [ -z "${SANDCASTLE_ADMIN_EMAIL:-}" ] && die "SANDCASTLE_ADMIN_EMAIL is required (set in sandcastle.env)"
-    [ -z "${SANDCASTLE_ADMIN_PASSWORD:-}" ] && die "SANDCASTLE_ADMIN_PASSWORD is required (set in sandcastle.env or use SANDCASTLE_ADMIN_PASSWORD_FILE)"
-    [ ${#SANDCASTLE_ADMIN_PASSWORD} -lt 6 ] && die "SANDCASTLE_ADMIN_PASSWORD must be at least 6 characters"
+
+    # When restoring from backup, admin credentials come from the backup DB —
+    # only SANDCASTLE_HOST (and TLS mode) are required from sandcastle.env.
+    if [ -z "$BACKUP_FILE" ]; then
+      [ -z "${SANDCASTLE_ADMIN_EMAIL:-}" ] && die "SANDCASTLE_ADMIN_EMAIL is required (set in sandcastle.env)"
+      [ -z "${SANDCASTLE_ADMIN_PASSWORD:-}" ] && die "SANDCASTLE_ADMIN_PASSWORD is required (set in sandcastle.env or use SANDCASTLE_ADMIN_PASSWORD_FILE)"
+      [ ${#SANDCASTLE_ADMIN_PASSWORD} -lt 6 ] && die "SANDCASTLE_ADMIN_PASSWORD must be at least 6 characters"
+    fi
 
     # SANDCASTLE_SUBNET no longer needed - networks allocated from dockyard pool
 
     SECRET_KEY_BASE=$(openssl rand -hex 64)
     DOCKER_GID=$(stat -c '%g' "$DOCKER_SOCK" 2>/dev/null || echo "988")
 
-    # Preserve DB password across reinstalls (user data)
-    POSTGRES_SECRETS_FILE="$SANDCASTLE_HOME/data/postgres/.secrets"
-    if [ -f "$POSTGRES_SECRETS_FILE" ]; then
+    if [ -n "$BACKUP_FILE" ]; then
+      # ── Extract secrets from the backup file ──────────────────────────────
+      # Pull just the secrets files from the archive without extracting everything.
+      info "Extracting secrets from backup..."
+      local _bk_work
+      _bk_work=$(mktemp -d)
+      trap 'rm -rf "$_bk_work"' EXIT
+      tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_bk_work" \
+        sandcastle-backup/secrets/rails.secrets \
+        sandcastle-backup/secrets/postgres.secrets \
+        2>/dev/null \
+        || die "Cannot extract secrets from backup — is this a valid Sandcastle backup?"
+
+      # Load DB password from backup
+      POSTGRES_SECRETS_FILE="$SANDCASTLE_HOME/data/postgres/.secrets"
+      mkdir -p "$SANDCASTLE_HOME/data/postgres"
+      cp "$_bk_work/sandcastle-backup/secrets/postgres.secrets" "$POSTGRES_SECRETS_FILE"
+      chmod 600 "$POSTGRES_SECRETS_FILE"
       # shellcheck source=/dev/null
       source "$POSTGRES_SECRETS_FILE"
-      info "Reusing existing database password"
-    else
-      DB_PASSWORD=$(openssl rand -hex 32)
-      mkdir -p "$SANDCASTLE_HOME/data/postgres"
-      echo "DB_PASSWORD=$DB_PASSWORD" > "$POSTGRES_SECRETS_FILE"
-      chmod 600 "$POSTGRES_SECRETS_FILE"
-      wrote "$POSTGRES_SECRETS_FILE"
-    fi
+      info "Using database password from backup"
 
-    # Preserve AR encryption keys across reinstalls — required to decrypt
-    # encrypted settings (SMTP password, OAuth secrets) stored in the database.
-    # Each install gets unique keys; losing them makes encrypted values unrecoverable.
-    RAILS_SECRETS_FILE="$SANDCASTLE_HOME/data/rails/.secrets"
-    if [ -f "$RAILS_SECRETS_FILE" ]; then
+      # Load AR encryption keys from backup
+      RAILS_SECRETS_FILE="$SANDCASTLE_HOME/data/rails/.secrets"
+      mkdir -p "$SANDCASTLE_HOME/data/rails"
+      cp "$_bk_work/sandcastle-backup/secrets/rails.secrets" "$RAILS_SECRETS_FILE"
+      chmod 600 "$RAILS_SECRETS_FILE"
       # shellcheck source=/dev/null
       source "$RAILS_SECRETS_FILE"
-      info "Reusing existing AR encryption keys"
+      info "Using AR encryption keys from backup"
+
+      rm -rf "$_bk_work"
+      trap - EXIT
     else
-      mkdir -p "$SANDCASTLE_HOME/data/rails"
-      AR_ENCRYPTION_PRIMARY_KEY=$(openssl rand -hex 16)
-      AR_ENCRYPTION_DETERMINISTIC_KEY=$(openssl rand -hex 16)
-      AR_ENCRYPTION_KEY_DERIVATION_SALT=$(openssl rand -hex 16)
-      cat > "$RAILS_SECRETS_FILE" <<SECRETS
+      # ── Normal fresh install: generate or reuse secrets ───────────────────
+
+      # Preserve DB password across reinstalls (user data)
+      POSTGRES_SECRETS_FILE="$SANDCASTLE_HOME/data/postgres/.secrets"
+      if [ -f "$POSTGRES_SECRETS_FILE" ]; then
+        # shellcheck source=/dev/null
+        source "$POSTGRES_SECRETS_FILE"
+        info "Reusing existing database password"
+      else
+        DB_PASSWORD=$(openssl rand -hex 32)
+        mkdir -p "$SANDCASTLE_HOME/data/postgres"
+        echo "DB_PASSWORD=$DB_PASSWORD" > "$POSTGRES_SECRETS_FILE"
+        chmod 600 "$POSTGRES_SECRETS_FILE"
+        wrote "$POSTGRES_SECRETS_FILE"
+      fi
+
+      # Preserve AR encryption keys across reinstalls — required to decrypt
+      # encrypted settings (SMTP password, OAuth secrets) stored in the database.
+      # Each install gets unique keys; losing them makes encrypted values unrecoverable.
+      RAILS_SECRETS_FILE="$SANDCASTLE_HOME/data/rails/.secrets"
+      if [ -f "$RAILS_SECRETS_FILE" ]; then
+        # shellcheck source=/dev/null
+        source "$RAILS_SECRETS_FILE"
+        info "Reusing existing AR encryption keys"
+      else
+        mkdir -p "$SANDCASTLE_HOME/data/rails"
+        AR_ENCRYPTION_PRIMARY_KEY=$(openssl rand -hex 16)
+        AR_ENCRYPTION_DETERMINISTIC_KEY=$(openssl rand -hex 16)
+        AR_ENCRYPTION_KEY_DERIVATION_SALT=$(openssl rand -hex 16)
+        cat > "$RAILS_SECRETS_FILE" <<SECRETS
 AR_ENCRYPTION_PRIMARY_KEY=$AR_ENCRYPTION_PRIMARY_KEY
 AR_ENCRYPTION_DETERMINISTIC_KEY=$AR_ENCRYPTION_DETERMINISTIC_KEY
 AR_ENCRYPTION_KEY_DERIVATION_SALT=$AR_ENCRYPTION_KEY_DERIVATION_SALT
 SECRETS
-      chmod 600 "$RAILS_SECRETS_FILE"
-      wrote "$RAILS_SECRETS_FILE"
-      warn "AR encryption keys generated. Back them up — losing them makes encrypted settings unrecoverable."
+        chmod 600 "$RAILS_SECRETS_FILE"
+        wrote "$RAILS_SECRETS_FILE"
+        warn "AR encryption keys generated. Back them up — losing them makes encrypted settings unrecoverable."
+      fi
     fi
 
     cat > "$SANDCASTLE_HOME/.env" <<EOF
@@ -2209,8 +2843,8 @@ AR_ENCRYPTION_DETERMINISTIC_KEY="${AR_ENCRYPTION_DETERMINISTIC_KEY}"
 AR_ENCRYPTION_KEY_DERIVATION_SALT="${AR_ENCRYPTION_KEY_DERIVATION_SALT}"
 DB_PASSWORD="${DB_PASSWORD}"
 SANDCASTLE_ADMIN_USER="${SANDCASTLE_ADMIN_USER}"
-SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL}"
-SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD}"
+SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL:-}"
+SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD:-}"
 SANDCASTLE_ADMIN_SSH_KEY="${SANDCASTLE_ADMIN_SSH_KEY:-}"
 DOCKER_GID="${DOCKER_GID}"
 DOCKER_SOCK="${DOCKER_SOCK}"
@@ -2530,30 +3164,80 @@ INITDB
 
   write_helper_scripts
 
+  # ── Install prerequisites and sandcastle-admin ────────────────────────────
+
+  install_prerequisites
+  write_admin_script
+
   # ── Start services ────────────────────────────────────────────────────────
 
-  info "Starting Sandcastle..."
   cd "$SANDCASTLE_HOME"
-  $DOCKER compose up -d
 
-  # ── Seed database (fresh install) ─────────────────────────────────────────
+  if [ "$FRESH_INSTALL" = true ] && [ -n "$BACKUP_FILE" ]; then
+    # ── Restore from backup ─────────────────────────────────────────────────
+    # Start postgres first, restore data, then bring up everything.
 
-  if [ "$FRESH_INSTALL" = true ]; then
-    info "Waiting for app to be ready..."
-    for i in $(seq 1 30); do
-      if curl -sfk https://localhost:${SANDCASTLE_HTTPS_PORT}/up >/dev/null 2>&1; then
-        break
-      fi
+    info "Starting PostgreSQL for restore..."
+    $DOCKER compose up -d postgres
+    local _i
+    for _i in $(seq 1 30); do
+      $DOCKER compose exec -T postgres \
+        pg_isready -U sandcastle -d sandcastle_production &>/dev/null && break
       sleep 2
     done
+    ok "PostgreSQL ready"
 
-    info "Seeding database..."
-    $DOCKER compose exec -T \
-      -e SANDCASTLE_ADMIN_USER="${SANDCASTLE_ADMIN_USER}" \
-      -e SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL}" \
-      -e SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD}" \
-      -e SANDCASTLE_ADMIN_SSH_KEY="${SANDCASTLE_ADMIN_SSH_KEY:-}" \
-      web ./bin/rails db:seed
+    # Extract and restore from the backup (db + data + images).
+    # Use sandcastle-admin restore for the actual restore logic.
+    info "Restoring from backup: $BACKUP_FILE"
+    SANDCASTLE_HOME="$SANDCASTLE_HOME" \
+      "$SANDCASTLE_HOME/bin/sandcastle-admin" restore "$BACKUP_FILE" \
+      --yes --skip-images 2>/dev/null \
+      || die "Restore failed — check the backup file and try again"
+
+    # Load snapshot images (docker save/load requires the daemon to be running)
+    # The restore command skipped them above; load manually now if present.
+    info "Starting Sandcastle..."
+    $DOCKER compose up -d
+
+    # Load snapshot images now that the Dockyard daemon is fully up
+    local _tmp_bk
+    _tmp_bk=$(mktemp -d)
+    tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_tmp_bk" \
+      sandcastle-backup/images 2>/dev/null || true
+    if [ -d "$_tmp_bk/sandcastle-backup/images" ]; then
+      info "Loading snapshot Docker images..."
+      local _img
+      for _img in "$_tmp_bk/sandcastle-backup/images/"*.tar; do
+        [ -f "$_img" ] || continue
+        info "  Loading $(basename "$_img")..."
+        $DOCKER load < "$_img" && ok "  $(basename "$_img")"
+      done
+    fi
+    rm -rf "$_tmp_bk"
+  else
+    info "Starting Sandcastle..."
+    $DOCKER compose up -d
+
+    # ── Seed database (fresh install without backup) ──────────────────────
+
+    if [ "$FRESH_INSTALL" = true ]; then
+      info "Waiting for app to be ready..."
+      for i in $(seq 1 30); do
+        if curl -sfk https://localhost:${SANDCASTLE_HTTPS_PORT}/up >/dev/null 2>&1; then
+          break
+        fi
+        sleep 2
+      done
+
+      info "Seeding database..."
+      $DOCKER compose exec -T \
+        -e SANDCASTLE_ADMIN_USER="${SANDCASTLE_ADMIN_USER}" \
+        -e SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL}" \
+        -e SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD}" \
+        -e SANDCASTLE_ADMIN_SSH_KEY="${SANDCASTLE_ADMIN_SSH_KEY:-}" \
+        web ./bin/rails db:seed
+    fi
   fi
 
   # ── Done ──────────────────────────────────────────────────────────────────
@@ -2577,7 +3261,11 @@ INITDB
     echo -e "  Dashboard:  ${BLUE}${base_url}${NC}"
   fi
 
-  if [ "$FRESH_INSTALL" = true ]; then
+  if [ "$FRESH_INSTALL" = true ] && [ -n "$BACKUP_FILE" ]; then
+    echo ""
+    echo -e "  ${GREEN}Restored from backup:${NC} $BACKUP_FILE"
+    echo -e "  Log in with your existing credentials."
+  elif [ "$FRESH_INSTALL" = true ]; then
     echo ""
     echo -e "  Admin login:"
     echo -e "    Email:     ${YELLOW}${SANDCASTLE_ADMIN_EMAIL}${NC}"
@@ -2678,8 +3366,8 @@ ARKEYS
 
 case "$COMMAND" in
   gen-env)    cmd_gen_env ;;
-  install)    load_env; derive_vars; cmd_install ;;
+  install)    load_env; derive_vars; cmd_install "$@" ;;
   update)     load_env; derive_vars; cmd_update ;;
-  reset)      load_env; derive_vars; cmd_destroy true; cmd_install ;;
+  reset)      load_env; derive_vars; cmd_destroy true; cmd_install "$@" ;;
   uninstall)  load_env; derive_vars; cmd_destroy ;;
 esac

--- a/installer/installer.sh.in
+++ b/installer/installer.sh.in
@@ -49,7 +49,7 @@ esac
 
 if [ "$COMMAND" = "help" ]; then
   cat <<'USAGE'
-Usage: installer.sh [COMMAND]
+Usage: installer.sh [COMMAND] [OPTIONS]
 
 Sandcastle installer — sets up Docker (via Dockyard), Traefik, and the
 Sandcastle platform.
@@ -62,15 +62,27 @@ Commands:
   uninstall    Remove Sandcastle completely
   help         Show this help message
 
+install options:
+  --from-backup <file>   Restore data from a backup file after installing.
+                         Secrets, database, and user data are loaded from the
+                         backup instead of being generated fresh.
+                         SANDCASTLE_HOST is still required in sandcastle.env.
+                         SANDCASTLE_ADMIN_EMAIL/PASSWORD are not required.
+
 Environment:
   SANDCASTLE_ENV   Path to config file (default search order:
                    ./sandcastle.env → <script_dir>/sandcastle.env →
                    $SANDCASTLE_HOME/etc/sandcastle.env)
 
-Workflow:
+Workflow (fresh install):
   1. installer.sh gen-env              # generate config
   2. vi sandcastle.env                 # edit to taste
   3. sudo installer.sh install         # install (finds ./sandcastle.env)
+
+Workflow (restore from backup):
+  1. installer.sh gen-env              # generate config (set SANDCASTLE_HOST)
+  2. vi sandcastle.env                 # set host, TLS mode — no admin password needed
+  3. sudo installer.sh install --from-backup ./sandcastle-backup-*.tar.zst
 USAGE
   exit 0
 fi
@@ -208,7 +220,7 @@ setup_passwordless_sudo() {
 setup_bashrc_path() {
   local profile="${SANDCASTLE_HOME}/.profile"
   local bashrc="${SANDCASTLE_HOME}/.bashrc"
-  local path_export="export PATH=${SANDCASTLE_HOME}/docker-runtime/bin:\$PATH"
+  local path_export="export PATH=${SANDCASTLE_HOME}/docker-runtime/bin:${SANDCASTLE_HOME}/bin:\$PATH"
 
   info "Configuring PATH in .profile and .bashrc..."
 
@@ -233,6 +245,38 @@ setup_bashrc_path() {
   ok "PATH configured in .profile and .bashrc"
 }
 
+# ═══ install_prerequisites ════════════════════════════════════════════════════
+# Install required host tools: zstd (for backup/restore), rsync (for data copy)
+
+install_prerequisites() {
+  local missing=()
+  command -v zstd >/dev/null 2>&1  || missing+=("zstd")
+  command -v rsync >/dev/null 2>&1 || missing+=("rsync")
+  if [ ${#missing[@]} -gt 0 ]; then
+    info "Installing prerequisites: ${missing[*]}..."
+    apt-get install -y "${missing[@]}" >/dev/null 2>&1 \
+      || warn "Failed to install ${missing[*]} — backup/restore may not work"
+    ok "Prerequisites installed: ${missing[*]}"
+  fi
+}
+
+# ═══ write_admin_script ═══════════════════════════════════════════════════════
+# Install sandcastle-admin to $SANDCASTLE_HOME/bin/
+
+write_admin_script() {
+  local bin_dir="$SANDCASTLE_HOME/bin"
+  mkdir -p "$bin_dir"
+
+  cat > "$bin_dir/sandcastle-admin" <<'__ADMIN_EOF__'
+@@TEMPLATE:templates/sandcastle-admin.sh@@
+__ADMIN_EOF__
+
+  chmod +x "$bin_dir/sandcastle-admin"
+  chown "${SANDCASTLE_USER}:${SANDCASTLE_GROUP}" "$bin_dir/sandcastle-admin"
+  wrote "$bin_dir/sandcastle-admin"
+  ok "sandcastle-admin installed to $bin_dir"
+}
+
 # ═══ setup_login_banner ══════════════════════════════════════════════════
 # Create a login banner showing Sandcastle version and info
 
@@ -255,6 +299,7 @@ BANNER_SCRIPT
 
 ensure_dirs() {
   mkdir -p "$SANDCASTLE_HOME"/etc
+  mkdir -p "$SANDCASTLE_HOME"/bin
   mkdir -p "$SANDCASTLE_HOME"/data/{users,sandboxes,wetty,postgres,snapshots}
   mkdir -p "$SANDCASTLE_HOME"/data/traefik/{dynamic,certs}
   chown "${SANDCASTLE_USER}:${SANDCASTLE_GROUP}" "$SANDCASTLE_HOME"
@@ -642,6 +687,22 @@ cmd_destroy() {
 # ═══ cmd_install ═════════════════════════════════════════════════════════════
 
 cmd_install() {
+  # Parse install-specific options
+  local BACKUP_FILE=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --from-backup)
+        BACKUP_FILE="$2"
+        [ -n "$BACKUP_FILE" ] || die "--from-backup requires a backup file path"
+        [ -f "$BACKUP_FILE" ] || die "Backup file not found: $BACKUP_FILE"
+        shift 2
+        ;;
+      *)
+        die "Unknown option for install: $1 (use --from-backup <file>)"
+        ;;
+    esac
+  done
+
   require_root
 
   if ! grep -qi ubuntu /etc/os-release 2>/dev/null; then
@@ -765,50 +826,92 @@ DYEOF
 
   if [ "$FRESH_INSTALL" = true ]; then
     [ -z "${SANDCASTLE_HOST:-}" ] && die "SANDCASTLE_HOST is required (set in sandcastle.env)"
-    [ -z "${SANDCASTLE_ADMIN_EMAIL:-}" ] && die "SANDCASTLE_ADMIN_EMAIL is required (set in sandcastle.env)"
-    [ -z "${SANDCASTLE_ADMIN_PASSWORD:-}" ] && die "SANDCASTLE_ADMIN_PASSWORD is required (set in sandcastle.env or use SANDCASTLE_ADMIN_PASSWORD_FILE)"
-    [ ${#SANDCASTLE_ADMIN_PASSWORD} -lt 6 ] && die "SANDCASTLE_ADMIN_PASSWORD must be at least 6 characters"
+
+    # When restoring from backup, admin credentials come from the backup DB —
+    # only SANDCASTLE_HOST (and TLS mode) are required from sandcastle.env.
+    if [ -z "$BACKUP_FILE" ]; then
+      [ -z "${SANDCASTLE_ADMIN_EMAIL:-}" ] && die "SANDCASTLE_ADMIN_EMAIL is required (set in sandcastle.env)"
+      [ -z "${SANDCASTLE_ADMIN_PASSWORD:-}" ] && die "SANDCASTLE_ADMIN_PASSWORD is required (set in sandcastle.env or use SANDCASTLE_ADMIN_PASSWORD_FILE)"
+      [ ${#SANDCASTLE_ADMIN_PASSWORD} -lt 6 ] && die "SANDCASTLE_ADMIN_PASSWORD must be at least 6 characters"
+    fi
 
     # SANDCASTLE_SUBNET no longer needed - networks allocated from dockyard pool
 
     SECRET_KEY_BASE=$(openssl rand -hex 64)
     DOCKER_GID=$(stat -c '%g' "$DOCKER_SOCK" 2>/dev/null || echo "988")
 
-    # Preserve DB password across reinstalls (user data)
-    POSTGRES_SECRETS_FILE="$SANDCASTLE_HOME/data/postgres/.secrets"
-    if [ -f "$POSTGRES_SECRETS_FILE" ]; then
+    if [ -n "$BACKUP_FILE" ]; then
+      # ── Extract secrets from the backup file ──────────────────────────────
+      # Pull just the secrets files from the archive without extracting everything.
+      info "Extracting secrets from backup..."
+      local _bk_work
+      _bk_work=$(mktemp -d)
+      trap 'rm -rf "$_bk_work"' EXIT
+      tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_bk_work" \
+        sandcastle-backup/secrets/rails.secrets \
+        sandcastle-backup/secrets/postgres.secrets \
+        2>/dev/null \
+        || die "Cannot extract secrets from backup — is this a valid Sandcastle backup?"
+
+      # Load DB password from backup
+      POSTGRES_SECRETS_FILE="$SANDCASTLE_HOME/data/postgres/.secrets"
+      mkdir -p "$SANDCASTLE_HOME/data/postgres"
+      cp "$_bk_work/sandcastle-backup/secrets/postgres.secrets" "$POSTGRES_SECRETS_FILE"
+      chmod 600 "$POSTGRES_SECRETS_FILE"
       # shellcheck source=/dev/null
       source "$POSTGRES_SECRETS_FILE"
-      info "Reusing existing database password"
-    else
-      DB_PASSWORD=$(openssl rand -hex 32)
-      mkdir -p "$SANDCASTLE_HOME/data/postgres"
-      echo "DB_PASSWORD=$DB_PASSWORD" > "$POSTGRES_SECRETS_FILE"
-      chmod 600 "$POSTGRES_SECRETS_FILE"
-      wrote "$POSTGRES_SECRETS_FILE"
-    fi
+      info "Using database password from backup"
 
-    # Preserve AR encryption keys across reinstalls — required to decrypt
-    # encrypted settings (SMTP password, OAuth secrets) stored in the database.
-    # Each install gets unique keys; losing them makes encrypted values unrecoverable.
-    RAILS_SECRETS_FILE="$SANDCASTLE_HOME/data/rails/.secrets"
-    if [ -f "$RAILS_SECRETS_FILE" ]; then
+      # Load AR encryption keys from backup
+      RAILS_SECRETS_FILE="$SANDCASTLE_HOME/data/rails/.secrets"
+      mkdir -p "$SANDCASTLE_HOME/data/rails"
+      cp "$_bk_work/sandcastle-backup/secrets/rails.secrets" "$RAILS_SECRETS_FILE"
+      chmod 600 "$RAILS_SECRETS_FILE"
       # shellcheck source=/dev/null
       source "$RAILS_SECRETS_FILE"
-      info "Reusing existing AR encryption keys"
+      info "Using AR encryption keys from backup"
+
+      rm -rf "$_bk_work"
+      trap - EXIT
     else
-      mkdir -p "$SANDCASTLE_HOME/data/rails"
-      AR_ENCRYPTION_PRIMARY_KEY=$(openssl rand -hex 16)
-      AR_ENCRYPTION_DETERMINISTIC_KEY=$(openssl rand -hex 16)
-      AR_ENCRYPTION_KEY_DERIVATION_SALT=$(openssl rand -hex 16)
-      cat > "$RAILS_SECRETS_FILE" <<SECRETS
+      # ── Normal fresh install: generate or reuse secrets ───────────────────
+
+      # Preserve DB password across reinstalls (user data)
+      POSTGRES_SECRETS_FILE="$SANDCASTLE_HOME/data/postgres/.secrets"
+      if [ -f "$POSTGRES_SECRETS_FILE" ]; then
+        # shellcheck source=/dev/null
+        source "$POSTGRES_SECRETS_FILE"
+        info "Reusing existing database password"
+      else
+        DB_PASSWORD=$(openssl rand -hex 32)
+        mkdir -p "$SANDCASTLE_HOME/data/postgres"
+        echo "DB_PASSWORD=$DB_PASSWORD" > "$POSTGRES_SECRETS_FILE"
+        chmod 600 "$POSTGRES_SECRETS_FILE"
+        wrote "$POSTGRES_SECRETS_FILE"
+      fi
+
+      # Preserve AR encryption keys across reinstalls — required to decrypt
+      # encrypted settings (SMTP password, OAuth secrets) stored in the database.
+      # Each install gets unique keys; losing them makes encrypted values unrecoverable.
+      RAILS_SECRETS_FILE="$SANDCASTLE_HOME/data/rails/.secrets"
+      if [ -f "$RAILS_SECRETS_FILE" ]; then
+        # shellcheck source=/dev/null
+        source "$RAILS_SECRETS_FILE"
+        info "Reusing existing AR encryption keys"
+      else
+        mkdir -p "$SANDCASTLE_HOME/data/rails"
+        AR_ENCRYPTION_PRIMARY_KEY=$(openssl rand -hex 16)
+        AR_ENCRYPTION_DETERMINISTIC_KEY=$(openssl rand -hex 16)
+        AR_ENCRYPTION_KEY_DERIVATION_SALT=$(openssl rand -hex 16)
+        cat > "$RAILS_SECRETS_FILE" <<SECRETS
 AR_ENCRYPTION_PRIMARY_KEY=$AR_ENCRYPTION_PRIMARY_KEY
 AR_ENCRYPTION_DETERMINISTIC_KEY=$AR_ENCRYPTION_DETERMINISTIC_KEY
 AR_ENCRYPTION_KEY_DERIVATION_SALT=$AR_ENCRYPTION_KEY_DERIVATION_SALT
 SECRETS
-      chmod 600 "$RAILS_SECRETS_FILE"
-      wrote "$RAILS_SECRETS_FILE"
-      warn "AR encryption keys generated. Back them up — losing them makes encrypted settings unrecoverable."
+        chmod 600 "$RAILS_SECRETS_FILE"
+        wrote "$RAILS_SECRETS_FILE"
+        warn "AR encryption keys generated. Back them up — losing them makes encrypted settings unrecoverable."
+      fi
     fi
 
     cat > "$SANDCASTLE_HOME/.env" <<EOF
@@ -826,8 +929,8 @@ AR_ENCRYPTION_DETERMINISTIC_KEY="${AR_ENCRYPTION_DETERMINISTIC_KEY}"
 AR_ENCRYPTION_KEY_DERIVATION_SALT="${AR_ENCRYPTION_KEY_DERIVATION_SALT}"
 DB_PASSWORD="${DB_PASSWORD}"
 SANDCASTLE_ADMIN_USER="${SANDCASTLE_ADMIN_USER}"
-SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL}"
-SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD}"
+SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL:-}"
+SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD:-}"
 SANDCASTLE_ADMIN_SSH_KEY="${SANDCASTLE_ADMIN_SSH_KEY:-}"
 DOCKER_GID="${DOCKER_GID}"
 DOCKER_SOCK="${DOCKER_SOCK}"
@@ -1134,30 +1237,80 @@ INITDB
 
   write_helper_scripts
 
+  # ── Install prerequisites and sandcastle-admin ────────────────────────────
+
+  install_prerequisites
+  write_admin_script
+
   # ── Start services ────────────────────────────────────────────────────────
 
-  info "Starting Sandcastle..."
   cd "$SANDCASTLE_HOME"
-  $DOCKER compose up -d
 
-  # ── Seed database (fresh install) ─────────────────────────────────────────
+  if [ "$FRESH_INSTALL" = true ] && [ -n "$BACKUP_FILE" ]; then
+    # ── Restore from backup ─────────────────────────────────────────────────
+    # Start postgres first, restore data, then bring up everything.
 
-  if [ "$FRESH_INSTALL" = true ]; then
-    info "Waiting for app to be ready..."
-    for i in $(seq 1 30); do
-      if curl -sfk https://localhost:${SANDCASTLE_HTTPS_PORT}/up >/dev/null 2>&1; then
-        break
-      fi
+    info "Starting PostgreSQL for restore..."
+    $DOCKER compose up -d postgres
+    local _i
+    for _i in $(seq 1 30); do
+      $DOCKER compose exec -T postgres \
+        pg_isready -U sandcastle -d sandcastle_production &>/dev/null && break
       sleep 2
     done
+    ok "PostgreSQL ready"
 
-    info "Seeding database..."
-    $DOCKER compose exec -T \
-      -e SANDCASTLE_ADMIN_USER="${SANDCASTLE_ADMIN_USER}" \
-      -e SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL}" \
-      -e SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD}" \
-      -e SANDCASTLE_ADMIN_SSH_KEY="${SANDCASTLE_ADMIN_SSH_KEY:-}" \
-      web ./bin/rails db:seed
+    # Extract and restore from the backup (db + data + images).
+    # Use sandcastle-admin restore for the actual restore logic.
+    info "Restoring from backup: $BACKUP_FILE"
+    SANDCASTLE_HOME="$SANDCASTLE_HOME" \
+      "$SANDCASTLE_HOME/bin/sandcastle-admin" restore "$BACKUP_FILE" \
+      --yes --skip-images 2>/dev/null \
+      || die "Restore failed — check the backup file and try again"
+
+    # Load snapshot images (docker save/load requires the daemon to be running)
+    # The restore command skipped them above; load manually now if present.
+    info "Starting Sandcastle..."
+    $DOCKER compose up -d
+
+    # Load snapshot images now that the Dockyard daemon is fully up
+    local _tmp_bk
+    _tmp_bk=$(mktemp -d)
+    tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_tmp_bk" \
+      sandcastle-backup/images 2>/dev/null || true
+    if [ -d "$_tmp_bk/sandcastle-backup/images" ]; then
+      info "Loading snapshot Docker images..."
+      local _img
+      for _img in "$_tmp_bk/sandcastle-backup/images/"*.tar; do
+        [ -f "$_img" ] || continue
+        info "  Loading $(basename "$_img")..."
+        $DOCKER load < "$_img" && ok "  $(basename "$_img")"
+      done
+    fi
+    rm -rf "$_tmp_bk"
+  else
+    info "Starting Sandcastle..."
+    $DOCKER compose up -d
+
+    # ── Seed database (fresh install without backup) ──────────────────────
+
+    if [ "$FRESH_INSTALL" = true ]; then
+      info "Waiting for app to be ready..."
+      for i in $(seq 1 30); do
+        if curl -sfk https://localhost:${SANDCASTLE_HTTPS_PORT}/up >/dev/null 2>&1; then
+          break
+        fi
+        sleep 2
+      done
+
+      info "Seeding database..."
+      $DOCKER compose exec -T \
+        -e SANDCASTLE_ADMIN_USER="${SANDCASTLE_ADMIN_USER}" \
+        -e SANDCASTLE_ADMIN_EMAIL="${SANDCASTLE_ADMIN_EMAIL}" \
+        -e SANDCASTLE_ADMIN_PASSWORD="${SANDCASTLE_ADMIN_PASSWORD}" \
+        -e SANDCASTLE_ADMIN_SSH_KEY="${SANDCASTLE_ADMIN_SSH_KEY:-}" \
+        web ./bin/rails db:seed
+    fi
   fi
 
   # ── Done ──────────────────────────────────────────────────────────────────
@@ -1181,7 +1334,11 @@ INITDB
     echo -e "  Dashboard:  ${BLUE}${base_url}${NC}"
   fi
 
-  if [ "$FRESH_INSTALL" = true ]; then
+  if [ "$FRESH_INSTALL" = true ] && [ -n "$BACKUP_FILE" ]; then
+    echo ""
+    echo -e "  ${GREEN}Restored from backup:${NC} $BACKUP_FILE"
+    echo -e "  Log in with your existing credentials."
+  elif [ "$FRESH_INSTALL" = true ]; then
     echo ""
     echo -e "  Admin login:"
     echo -e "    Email:     ${YELLOW}${SANDCASTLE_ADMIN_EMAIL}${NC}"
@@ -1282,8 +1439,8 @@ ARKEYS
 
 case "$COMMAND" in
   gen-env)    cmd_gen_env ;;
-  install)    load_env; derive_vars; cmd_install ;;
+  install)    load_env; derive_vars; cmd_install "$@" ;;
   update)     load_env; derive_vars; cmd_update ;;
-  reset)      load_env; derive_vars; cmd_destroy true; cmd_install ;;
+  reset)      load_env; derive_vars; cmd_destroy true; cmd_install "$@" ;;
   uninstall)  load_env; derive_vars; cmd_destroy ;;
 esac

--- a/installer/templates/sandcastle-admin.sh
+++ b/installer/templates/sandcastle-admin.sh
@@ -1,0 +1,533 @@
+#!/bin/bash
+# sandcastle-admin — Sandcastle backup/restore administration tool
+# Usage: sandcastle-admin <command> [options]
+set -euo pipefail
+
+# ═══ Colors & helpers ════════════════════════════════════════════════════════
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+die()   { error "$@"; exit 1; }
+
+# ═══ Config ══════════════════════════════════════════════════════════════════
+
+SANDCASTLE_HOME="${SANDCASTLE_HOME:-/sandcastle}"
+
+# Load installed env
+ENV_FILE="$SANDCASTLE_HOME/etc/sandcastle.env"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+fi
+
+DOCKYARD_ROOT="${DOCKYARD_ROOT:-$SANDCASTLE_HOME}"
+DOCKER="${DOCKYARD_ROOT}/docker-runtime/bin/docker"
+COMPOSE_FILE="$SANDCASTLE_HOME/docker-compose.yml"
+
+[ -x "$DOCKER" ] || die "Docker not found at $DOCKER — is Sandcastle installed?"
+[ -f "$COMPOSE_FILE" ] || die "docker-compose.yml not found at $COMPOSE_FILE — is Sandcastle installed?"
+
+# ═══ BTRFS helpers ═══════════════════════════════════════════════════════════
+
+is_btrfs() {
+  stat -f --format="%T" "$1" 2>/dev/null | grep -qi btrfs
+}
+
+btrfs_snapshot_r() {
+  btrfs subvolume snapshot -r "$1" "$2" 2>/dev/null
+}
+
+btrfs_delete() {
+  btrfs subvolume delete "$1" 2>/dev/null || rm -rf "$1"
+}
+
+# ═══ cmd_backup ══════════════════════════════════════════════════════════════
+
+cmd_backup() {
+  local output=""
+  local skip_sandbox_volumes=false
+  local skip_snapshot_images=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --output|-o)
+        output="$2"
+        shift 2
+        ;;
+      --no-sandbox-volumes)
+        skip_sandbox_volumes=true
+        shift
+        ;;
+      --no-snapshot-images)
+        skip_snapshot_images=true
+        shift
+        ;;
+      *)
+        die "Unknown option: $1 (run 'sandcastle-admin help' for usage)"
+        ;;
+    esac
+  done
+
+  command -v zstd >/dev/null 2>&1 || die "zstd not found — install: apt-get install zstd"
+  command -v rsync >/dev/null 2>&1 || die "rsync not found — install: apt-get install rsync"
+
+  # Get app version from the running web container (fall back gracefully)
+  local version
+  version=$($DOCKER compose -f "$COMPOSE_FILE" exec -T web \
+    ./bin/rails runner "puts Sandcastle::VERSION rescue puts '0.0.0'" 2>/dev/null \
+    | tail -1 || echo "unknown")
+  version="${version:-unknown}"
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%d_%H%M%S")
+  local default_output="./sandcastle-backup-${timestamp}-${version}.tar.zst"
+  output="${output:-$default_output}"
+
+  local work_dir
+  work_dir=$(mktemp -d)
+  trap 'rm -rf "$work_dir"' EXIT
+
+  local backup_dir="$work_dir/sandcastle-backup"
+  mkdir -p "$backup_dir"/{db,secrets,data}
+
+  echo ""
+  echo -e "${BLUE}═══ Sandcastle Backup ═══${NC}"
+  echo ""
+  info "Output: $output"
+  echo ""
+
+  # ── Dump PostgreSQL databases ─────────────────────────────────────────────
+
+  info "Dumping PostgreSQL databases..."
+  local db
+  for db in sandcastle_production sandcastle_production_cache sandcastle_production_queue sandcastle_production_cable; do
+    info "  pg_dump $db..."
+    $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+      pg_dump -U sandcastle --format=custom "$db" \
+      > "$backup_dir/db/${db}.pgdump"
+    ok "  ${db}.pgdump"
+  done
+
+  # ── Secrets ───────────────────────────────────────────────────────────────
+
+  info "Backing up secrets..."
+  local rails_secrets="$SANDCASTLE_HOME/data/rails/.secrets"
+  local postgres_secrets="$SANDCASTLE_HOME/data/postgres/.secrets"
+
+  if [ -f "$rails_secrets" ]; then
+    cp "$rails_secrets" "$backup_dir/secrets/rails.secrets"
+    ok "  rails.secrets"
+  else
+    warn "  Rails secrets not found at $rails_secrets"
+  fi
+
+  if [ -f "$postgres_secrets" ]; then
+    cp "$postgres_secrets" "$backup_dir/secrets/postgres.secrets"
+    ok "  postgres.secrets"
+  else
+    warn "  Postgres secrets not found at $postgres_secrets"
+  fi
+
+  # Let's Encrypt cert (nice-to-have)
+  local acme_json="$SANDCASTLE_HOME/data/traefik/acme.json"
+  if [ -f "$acme_json" ] && [ -s "$acme_json" ]; then
+    cp "$acme_json" "$backup_dir/secrets/acme.json"
+    ok "  acme.json"
+  fi
+
+  # ── User data ─────────────────────────────────────────────────────────────
+
+  info "Backing up user data..."
+  mkdir -p "$backup_dir/data/users"
+  if [ -d "$SANDCASTLE_HOME/data/users" ]; then
+    if is_btrfs "$SANDCASTLE_HOME/data/users"; then
+      local snap_users="$SANDCASTLE_HOME/data/.backup-snap-users-$$"
+      btrfs_snapshot_r "$SANDCASTLE_HOME/data/users" "$snap_users"
+      rsync -a --exclude='*/home/.docker' "$snap_users/" "$backup_dir/data/users/"
+      btrfs_delete "$snap_users"
+    else
+      rsync -a --exclude='*/home/.docker' "$SANDCASTLE_HOME/data/users/" "$backup_dir/data/users/"
+    fi
+    ok "  users/"
+  fi
+
+  # ── Sandbox volumes ───────────────────────────────────────────────────────
+
+  if [ "$skip_sandbox_volumes" = false ]; then
+    info "Backing up sandbox volumes..."
+    mkdir -p "$backup_dir/data/sandboxes"
+    if [ -d "$SANDCASTLE_HOME/data/sandboxes" ]; then
+      if is_btrfs "$SANDCASTLE_HOME/data/sandboxes"; then
+        local snap_sandboxes="$SANDCASTLE_HOME/data/.backup-snap-sandboxes-$$"
+        btrfs_snapshot_r "$SANDCASTLE_HOME/data/sandboxes" "$snap_sandboxes"
+        rsync -a "$snap_sandboxes/" "$backup_dir/data/sandboxes/"
+        btrfs_delete "$snap_sandboxes"
+      else
+        rsync -a "$SANDCASTLE_HOME/data/sandboxes/" "$backup_dir/data/sandboxes/"
+      fi
+      ok "  sandboxes/"
+    fi
+  else
+    info "Skipping sandbox volumes (--no-sandbox-volumes)"
+  fi
+
+  # ── Snapshot dirs ─────────────────────────────────────────────────────────
+
+  if [ -d "$SANDCASTLE_HOME/data/snapshots" ]; then
+    info "Backing up snapshot directories..."
+    mkdir -p "$backup_dir/data/snapshots"
+    rsync -a "$SANDCASTLE_HOME/data/snapshots/" "$backup_dir/data/snapshots/"
+    ok "  snapshots/"
+  fi
+
+  # ── Snapshot Docker images ────────────────────────────────────────────────
+
+  if [ "$skip_snapshot_images" = false ]; then
+    local snap_images
+    snap_images=$($DOCKER images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+      | grep '^sc-snap-' || true)
+    if [ -n "$snap_images" ]; then
+      info "Saving snapshot Docker images..."
+      mkdir -p "$backup_dir/images"
+      local img fname
+      while IFS= read -r img; do
+        fname=$(echo "$img" | tr '/:' '-').tar
+        info "  docker save $img..."
+        $DOCKER save "$img" > "$backup_dir/images/$fname"
+        ok "  $fname"
+      done <<< "$snap_images"
+    fi
+  else
+    info "Skipping snapshot images (--no-snapshot-images)"
+  fi
+
+  # ── Manifest ──────────────────────────────────────────────────────────────
+
+  local user_count sandbox_count snapshot_count
+  user_count=$(find "$SANDCASTLE_HOME/data/users" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l || echo 0)
+  sandbox_count=$(find "$SANDCASTLE_HOME/data/sandboxes" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l || echo 0)
+  snapshot_count=$(find "$SANDCASTLE_HOME/data/snapshots" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l || echo 0)
+
+  local includes='"db","secrets","user_data"'
+  [ "$skip_sandbox_volumes" = false ] && includes="$includes,\"sandbox_volumes\""
+  [ -d "$SANDCASTLE_HOME/data/snapshots" ] && includes="$includes,\"snapshot_dirs\""
+  [ "$skip_snapshot_images" = false ] && includes="$includes,\"snapshot_images\""
+
+  cat > "$backup_dir/manifest.json" <<MANIFEST
+{
+  "version": "${version}",
+  "schema_version": 1,
+  "created_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "hostname": "$(hostname)",
+  "includes": [${includes}],
+  "user_count": ${user_count},
+  "sandbox_count": ${sandbox_count},
+  "snapshot_count": ${snapshot_count}
+}
+MANIFEST
+
+  # ── Create archive ────────────────────────────────────────────────────────
+
+  info "Creating archive..."
+  tar --use-compress-program=zstd -cf "$output" -C "$work_dir" sandcastle-backup
+
+  local size
+  size=$(du -sh "$output" 2>/dev/null | cut -f1 || echo "?")
+
+  echo ""
+  ok "Backup complete: $output (${size})"
+  echo ""
+}
+
+# ═══ cmd_restore ══════════════════════════════════════════════════════════════
+
+cmd_restore() {
+  local backup_file=""
+  local skip_db=false
+  local skip_data=false
+  local skip_images=false
+  local yes=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --skip-db)     skip_db=true; shift ;;
+      --skip-data)   skip_data=true; shift ;;
+      --skip-images) skip_images=true; shift ;;
+      --yes|-y)      yes=true; shift ;;
+      -*)            die "Unknown option: $1 (run 'sandcastle-admin help' for usage)" ;;
+      *)             backup_file="$1"; shift ;;
+    esac
+  done
+
+  [ -n "$backup_file" ] || die "Usage: sandcastle-admin restore <backup-file.tar.zst> [options]"
+  [ -f "$backup_file" ] || die "Backup file not found: $backup_file"
+
+  command -v zstd >/dev/null 2>&1 || die "zstd not found — install: apt-get install zstd"
+
+  # ── Read and validate manifest ────────────────────────────────────────────
+
+  local work_dir
+  work_dir=$(mktemp -d)
+  trap 'rm -rf "$work_dir"' EXIT
+
+  info "Reading backup manifest..."
+  tar --use-compress-program=zstd -xf "$backup_file" -C "$work_dir" \
+    sandcastle-backup/manifest.json 2>/dev/null \
+    || die "Cannot read manifest — is this a valid Sandcastle backup file?"
+
+  local manifest="$work_dir/sandcastle-backup/manifest.json"
+
+  # Parse with python3 (always available on Ubuntu)
+  local bk_version bk_created bk_hostname bk_schema bk_users bk_sandboxes bk_snapshots
+  bk_version=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('version','?'))")
+  bk_created=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('created_at','?'))")
+  bk_hostname=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('hostname','?'))")
+  bk_schema=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('schema_version',1))")
+  bk_users=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('user_count',0))")
+  bk_sandboxes=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('sandbox_count',0))")
+  bk_snapshots=$(python3 -c "import json; d=json.load(open('$manifest')); print(d.get('snapshot_count',0))")
+
+  if [ "${bk_schema}" -gt 1 ] 2>/dev/null; then
+    warn "Backup schema_version=${bk_schema} is newer than supported (1) — proceeding anyway"
+  fi
+
+  echo ""
+  echo -e "${BLUE}═══ Sandcastle Restore ═══${NC}"
+  echo ""
+  echo -e "  Backup version:  ${YELLOW}${bk_version}${NC}"
+  echo -e "  Created:         ${bk_created}"
+  echo -e "  Source host:     ${bk_hostname}"
+  echo -e "  Users:           ${bk_users}"
+  echo -e "  Sandboxes:       ${bk_sandboxes}"
+  echo -e "  Snapshots:       ${bk_snapshots}"
+  echo ""
+  echo -e "${YELLOW}WARNING: This will overwrite all current Sandcastle data!${NC}"
+  echo ""
+
+  if [ "$yes" != true ]; then
+    read -rp "Type 'yes' to confirm: " CONFIRM
+    [ "$CONFIRM" = "yes" ] || die "Aborted"
+  fi
+
+  # ── Step 1: Stop Sandcastle ───────────────────────────────────────────────
+
+  info "Step 1/7: Stopping Sandcastle..."
+  cd "$SANDCASTLE_HOME"
+  $DOCKER compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+  ok "Services stopped"
+
+  # ── Extract backup archive ────────────────────────────────────────────────
+
+  info "Extracting backup archive..."
+  tar --use-compress-program=zstd -xf "$backup_file" -C "$work_dir"
+  local bk_dir="$work_dir/sandcastle-backup"
+
+  # ── Step 2: Restore secrets ───────────────────────────────────────────────
+
+  info "Step 2/7: Restoring secrets..."
+
+  local main_env="$SANDCASTLE_HOME/.env"
+
+  if [ -f "$bk_dir/secrets/rails.secrets" ]; then
+    mkdir -p "$SANDCASTLE_HOME/data/rails"
+    cp "$bk_dir/secrets/rails.secrets" "$SANDCASTLE_HOME/data/rails/.secrets"
+    chmod 600 "$SANDCASTLE_HOME/data/rails/.secrets"
+    # Inject AR keys into .env
+    set -a
+    # shellcheck source=/dev/null
+    source "$bk_dir/secrets/rails.secrets"
+    set +a
+    local key val
+    for key in AR_ENCRYPTION_PRIMARY_KEY AR_ENCRYPTION_DETERMINISTIC_KEY AR_ENCRYPTION_KEY_DERIVATION_SALT; do
+      val="${!key:-}"
+      if [ -n "$val" ]; then
+        if grep -q "^${key}=" "$main_env" 2>/dev/null; then
+          sed -i "s|^${key}=.*|${key}=${val}|" "$main_env"
+        else
+          echo "${key}=${val}" >> "$main_env"
+        fi
+      fi
+    done
+    ok "  rails.secrets"
+  fi
+
+  if [ -f "$bk_dir/secrets/postgres.secrets" ]; then
+    mkdir -p "$SANDCASTLE_HOME/data/postgres"
+    cp "$bk_dir/secrets/postgres.secrets" "$SANDCASTLE_HOME/data/postgres/.secrets"
+    chmod 600 "$SANDCASTLE_HOME/data/postgres/.secrets"
+    set -a
+    # shellcheck source=/dev/null
+    source "$bk_dir/secrets/postgres.secrets"
+    set +a
+    if [ -n "${DB_PASSWORD:-}" ]; then
+      if grep -q "^DB_PASSWORD=" "$main_env" 2>/dev/null; then
+        sed -i "s|^DB_PASSWORD=.*|DB_PASSWORD=${DB_PASSWORD}|" "$main_env"
+      else
+        echo "DB_PASSWORD=${DB_PASSWORD}" >> "$main_env"
+      fi
+    fi
+    ok "  postgres.secrets"
+  fi
+
+  if [ -f "$bk_dir/secrets/acme.json" ]; then
+    mkdir -p "$SANDCASTLE_HOME/data/traefik"
+    cp "$bk_dir/secrets/acme.json" "$SANDCASTLE_HOME/data/traefik/acme.json"
+    chmod 600 "$SANDCASTLE_HOME/data/traefik/acme.json"
+    ok "  acme.json"
+  fi
+
+  # Reload .env so subsequent docker compose picks up updated secrets
+  set -a
+  # shellcheck source=/dev/null
+  source "$main_env"
+  set +a
+
+  # ── Step 3 & 4: Database restore ──────────────────────────────────────────
+
+  if [ "$skip_db" = false ]; then
+    info "Step 3/7: Starting PostgreSQL..."
+    $DOCKER compose -f "$COMPOSE_FILE" up -d postgres
+    local i
+    for i in $(seq 1 30); do
+      $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+        pg_isready -U sandcastle -d sandcastle_production &>/dev/null && break
+      sleep 2
+    done
+    ok "PostgreSQL ready"
+
+    info "Step 4/7: Restoring databases..."
+    local db dump
+    for db in sandcastle_production sandcastle_production_cache sandcastle_production_queue sandcastle_production_cable; do
+      dump="$bk_dir/db/${db}.pgdump"
+      if [ -f "$dump" ]; then
+        info "  Restoring $db..."
+        # Ensure the database exists (for cache/queue/cable on first restore)
+        $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+          psql -U sandcastle -d postgres \
+          -c "SELECT 1 FROM pg_database WHERE datname='${db}'" \
+          | grep -q "1 row" \
+          || $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+               createdb -U sandcastle "$db" 2>/dev/null || true
+        $DOCKER compose -f "$COMPOSE_FILE" exec -T postgres \
+          pg_restore -U sandcastle -d "$db" --clean --if-exists < "$dump" 2>/dev/null || true
+        ok "  $db"
+      else
+        warn "  No dump found for $db — skipping"
+      fi
+    done
+  else
+    info "Step 3/7: Skipping database (--skip-db)"
+    info "Step 4/7: Skipping database (--skip-db)"
+  fi
+
+  # ── Step 5: Run migrations ────────────────────────────────────────────────
+
+  info "Step 5/7: Running migrations..."
+  $DOCKER compose -f "$COMPOSE_FILE" run --rm migrate 2>/dev/null \
+    || warn "Migrate service not available — run 'rails db:migrate' manually if needed"
+  ok "Migrations done"
+
+  # ── Step 6: Restore filesystem data ──────────────────────────────────────
+
+  if [ "$skip_data" = false ]; then
+    info "Step 6/7: Restoring filesystem data..."
+
+    if [ -d "$bk_dir/data/users" ]; then
+      mkdir -p "$SANDCASTLE_HOME/data/users"
+      rsync -a --delete "$bk_dir/data/users/" "$SANDCASTLE_HOME/data/users/"
+      ok "  users/"
+    fi
+
+    if [ -d "$bk_dir/data/sandboxes" ]; then
+      mkdir -p "$SANDCASTLE_HOME/data/sandboxes"
+      rsync -a --delete "$bk_dir/data/sandboxes/" "$SANDCASTLE_HOME/data/sandboxes/"
+      ok "  sandboxes/"
+    fi
+
+    if [ -d "$bk_dir/data/snapshots" ]; then
+      mkdir -p "$SANDCASTLE_HOME/data/snapshots"
+      rsync -a --delete "$bk_dir/data/snapshots/" "$SANDCASTLE_HOME/data/snapshots/"
+      ok "  snapshots/"
+    fi
+  else
+    info "Step 6/7: Skipping filesystem data (--skip-data)"
+  fi
+
+  # ── Step 7: Load snapshot Docker images ───────────────────────────────────
+
+  if [ "$skip_images" = false ] && [ -d "$bk_dir/images" ]; then
+    info "Step 7/7: Loading snapshot Docker images..."
+    local img_tar
+    for img_tar in "$bk_dir/images/"*.tar; do
+      [ -f "$img_tar" ] || continue
+      info "  Loading $(basename "$img_tar")..."
+      $DOCKER load < "$img_tar"
+      ok "  $(basename "$img_tar")"
+    done
+  else
+    info "Step 7/7: Skipping snapshot images"
+  fi
+
+  # ── Start Sandcastle ───────────────────────────────────────────────────────
+
+  info "Starting Sandcastle..."
+  cd "$SANDCASTLE_HOME"
+  $DOCKER compose -f "$COMPOSE_FILE" up -d
+  ok "Sandcastle started"
+
+  echo ""
+  ok "Restore complete!"
+  echo ""
+}
+
+# ═══ Help ════════════════════════════════════════════════════════════════════
+
+cmd_help() {
+  cat <<'USAGE'
+Usage: sandcastle-admin <command> [options]
+
+Commands:
+  backup     Create a full backup of this Sandcastle instance
+  restore    Restore a Sandcastle instance from a backup file
+  help       Show this help message
+
+backup [options]:
+  --output <path>           Output path (default: ./sandcastle-backup-<ts>-<ver>.tar.zst)
+  --no-sandbox-volumes      Skip /data/sandboxes/*/vol (faster/smaller)
+  --no-snapshot-images      Skip docker save of snapshot images
+
+restore <file.tar.zst> [options]:
+  --skip-db                 Skip database restore
+  --skip-data               Skip filesystem data restore
+  --skip-images             Skip loading snapshot Docker images
+  --yes, -y                 Skip confirmation prompt
+
+Examples:
+  sandcastle-admin backup
+  sandcastle-admin backup --output /mnt/backups/sc.tar.zst --no-snapshot-images
+  sandcastle-admin restore /mnt/backups/sandcastle-backup-2026-03-01.tar.zst
+  sandcastle-admin restore /mnt/backups/sc.tar.zst --skip-db --yes
+USAGE
+}
+
+# ═══ Dispatch ════════════════════════════════════════════════════════════════
+
+COMMAND="${1:-help}"
+shift 2>/dev/null || true
+
+case "$COMMAND" in
+  backup)         cmd_backup "$@" ;;
+  restore)        cmd_restore "$@" ;;
+  help|-h|--help) cmd_help ;;
+  *) die "Unknown command: $COMMAND — run 'sandcastle-admin help'" ;;
+esac


### PR DESCRIPTION
Implements `sandcastle-admin backup` and `sandcastle-admin restore` commands, and adds `installer.sh install --from-backup <file>` to set up a new Sandcastle instance from an existing backup.

## Changes

- `installer/templates/sandcastle-admin.sh`: new bash script with backup and restore commands
- `installer/installer.sh.in` + `installer.sh`: adds `--from-backup` flag, `install_prerequisites()`, `write_admin_script()`, PATH update

Closes #64

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added install-from-backup functionality to restore data during fresh installation using the `--from-backup` option.
  * Introduced new administration tool with backup and restore capabilities for data preservation and recovery.

* **Chores**
  * Enhanced environment PATH configuration for improved binary discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->