### PR TITLE
fix: resolve three dev environment errors

### DIFF
--- a/app/controllers/sandboxes_controller.rb
+++ b/app/controllers/sandboxes_controller.rb
@@ -81,11 +81,15 @@ class SandboxesController < ApplicationController
       redirect_to root_path, notice: "Creating sandcastle #{sandbox.name}..."
     else
       @snapshots = SandboxManager.new.list_snapshots(user: Current.user)
+      @btrfs_available = BtrfsHelper.btrfs?
+      @defaults = Current.user
       flash.now[:alert] = "Failed to create sandbox: #{sandbox.errors.full_messages.join(', ')}"
       render :new, status: :unprocessable_entity
     end
   rescue => e
     @snapshots = SandboxManager.new.list_snapshots(user: Current.user)
+    @btrfs_available = BtrfsHelper.btrfs?
+    @defaults = Current.user
     flash.now[:alert] = "Failed to create sandbox: #{e.message}"
     render :new, status: :unprocessable_entity
   end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -51,7 +51,7 @@
               Connect Tailscale to access them seamlessly from anywhere on your tailnet.
             </span>
           </div>
-          <%= link_to tailscale_path, class: "shrink-0 bg-white text-amber-600 font-semibold text-sm px-4 py-1.5 rounded-lg hover:bg-amber-50 transition-colors" do %>
+          <%= link_to main_app.tailscale_path, class: "shrink-0 bg-white text-amber-600 font-semibold text-sm px-4 py-1.5 rounded-lg hover:bg-amber-50 transition-colors" do %>
             Connect Tailscale &rarr;
           <% end %>
         </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,6 +76,11 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  # Disable origin-based CSRF check in development. When accessed via a reverse
+  # proxy or forwarded preview URL (e.g. Gitpod, Traefik), the browser sends a
+  # null origin which Rails cannot verify. The token-based CSRF check still applies.
+  config.action_controller.forgery_protection_origin_check = false
+
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 


### PR DESCRIPTION
Three bugs hit when running the dev environment via a reverse proxy (Traefik + Gitpod preview URL).

## Changes

**`config/environments/development.rb` — CSRF origin check**
Rails 8 validates the `Origin` header against the request host. Requests through Traefik/preview proxies arrive with `Origin: null` (opaque origin), causing `InvalidAuthenticityToken` on every login attempt. Disabling `forgery_protection_origin_check` in development only; token-based CSRF still applies.

**`app/controllers/sandboxes_controller.rb` — nil `@defaults` on create failure**
The `new` action sets `@defaults = Current.user` and `@btrfs_available`. The `create` action's validation-failure and rescue paths only set `@snapshots`, leaving the other two nil. Re-rendering `new.html.erb` then raised `NoMethodError: undefined method 'default_mount_home' for nil`.

**`app/views/layouts/admin.html.erb` — `tailscale_path` in engine context**
`solid_errors` mounts as a Rails engine and uses `admin.html.erb` as its layout. Engine view contexts only resolve their own routes, so bare `tailscale_path` raises `NameError`. Changed to `main_app.tailscale_path` which works in both host and engine contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tailscale connection link routing in the admin panel to work correctly in all contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->