### PR TITLE
feat(projects): per-user Project profiles for sandbox defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Rails secret key (generate with: bin/rails secret)
 SECRET_KEY_BASE=
 
+# UID/GID used by the Rails app user inside deploy/test containers
+SANDCASTLE_UID=22051
+SANDCASTLE_GID=22051
+
 # Public hostname of the Sandcastle server
 SANDCASTLE_HOST=sandcastle.rocks
 

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -1,0 +1,57 @@
+module Api
+  class ProjectsController < BaseController
+    before_action :set_project, only: %i[show destroy]
+
+    def index
+      authorize Project
+      render json: policy_scope(Project).order(:name).map { |project| project_json(project) }
+    end
+
+    def show
+      render json: project_json(@project)
+    end
+
+    def create
+      project = current_user.projects.build(project_params)
+      authorize project
+      project.save!
+      render json: project_json(project), status: :created
+    end
+
+    def destroy
+      @project.destroy!
+      render json: { status: "deleted" }
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:id])
+      authorize @project
+    end
+
+    def project_params
+      params.require(:project).permit(
+        :name, :path, :image, :tailscale, :vnc_enabled, :vnc_geometry,
+        :vnc_depth, :docker_enabled, :smb_enabled, :ssh_start_tmux
+      )
+    end
+
+    def project_json(project)
+      {
+        id: project.id,
+        name: project.name,
+        path: project.path,
+        image: project.image,
+        tailscale: project.tailscale,
+        vnc_enabled: project.vnc_enabled,
+        vnc_geometry: project.vnc_geometry,
+        vnc_depth: project.vnc_depth,
+        docker_enabled: project.docker_enabled,
+        smb_enabled: project.smb_enabled,
+        ssh_start_tmux: project.ssh_start_tmux,
+        created_at: project.created_at
+      }
+    end
+  end
+end

--- a/app/controllers/api/sandboxes_controller.rb
+++ b/app/controllers/api/sandboxes_controller.rb
@@ -32,12 +32,31 @@ module Api
       from_snapshot_name = params[:from_snapshot].presence || params[:snapshot].presence
       restore_layers     = params[:restore_layers].present? ? Array(params[:restore_layers]) : nil
 
+      project = if params[:project_id].present?
+        current_user.projects.find(params[:project_id])
+      elsif params[:project_name].present?
+        current_user.projects.find_by!(name: params[:project_name])
+      end
+
       image = if from_snapshot_name.present?
         # Try to find DB record first
         snap = Snapshot.find_by(user: current_user, name: from_snapshot_name)
         snap&.docker_image || "sc-snap-#{current_user.name}:#{from_snapshot_name}"
       else
-        params[:image].presence || SandboxManager::DEFAULT_IMAGE
+        params[:image].presence || project&.image || SandboxManager::DEFAULT_IMAGE
+      end
+
+      project_path = params[:project_path].presence
+      mount_home = project.present? ? false : (params.key?(:mount_home) ? params[:mount_home] : current_user.default_mount_home)
+      home_path = project.present? ? project.path : params[:home_path].presence
+      data_path = project.present? ? project.path : (params.key?(:data_path) ? params[:data_path] : current_user.default_data_path)
+      project_name = project&.name
+
+      if project_path.present?
+        mount_home = false
+        home_path = project_path
+        data_path = project_path
+        project_name = File.basename(project_path)
       end
 
       # Build sandbox record (fall back to the user's personal defaults where
@@ -46,16 +65,18 @@ module Api
         name: params.require(:name),
         status: "pending",
         image: image,
-        mount_home: params.key?(:mount_home) ? params[:mount_home] : current_user.default_mount_home,
-        data_path: params.key?(:data_path) ? params[:data_path] : current_user.default_data_path,
-        tailscale: params.fetch(:tailscale) { current_user.tailscale_enabled? },
-        vnc_enabled: params.key?(:vnc_enabled) ? params[:vnc_enabled] : current_user.default_vnc_enabled,
-        vnc_geometry: params[:vnc_geometry] || "1280x900",
-        vnc_depth: params[:vnc_depth]&.to_i || 24,
-        docker_enabled: params.key?(:docker_enabled) ? params[:docker_enabled] : current_user.default_docker_enabled,
-        ssh_start_tmux: params.key?(:ssh_start_tmux) ? params[:ssh_start_tmux] : nil,
+        project_name: project_name,
+        mount_home: mount_home,
+        home_path: home_path,
+        data_path: data_path,
+        tailscale: project.present? ? project.tailscale : params.fetch(:tailscale) { current_user.tailscale_enabled? },
+        vnc_enabled: project.present? ? project.vnc_enabled : (params.key?(:vnc_enabled) ? params[:vnc_enabled] : current_user.default_vnc_enabled),
+        vnc_geometry: project.present? ? project.vnc_geometry : (params[:vnc_geometry] || "1280x900"),
+        vnc_depth: project.present? ? project.vnc_depth : (params[:vnc_depth]&.to_i || 24),
+        docker_enabled: project.present? ? project.docker_enabled : (params.key?(:docker_enabled) ? params[:docker_enabled] : current_user.default_docker_enabled),
+        ssh_start_tmux: project.present? ? project.ssh_start_tmux : (params.key?(:ssh_start_tmux) ? params[:ssh_start_tmux] : nil),
         temporary: params[:temporary] || false,
-        smb_enabled: params.key?(:smb_enabled) ? params[:smb_enabled] : (current_user.default_smb_enabled && current_user.tailscale_enabled? && current_user.smb_password.present?)
+        smb_enabled: project.present? ? project.smb_enabled : (params.key?(:smb_enabled) ? params[:smb_enabled] : (current_user.default_smb_enabled && current_user.tailscale_enabled? && current_user.smb_password.present?))
       )
 
       sandbox.save!
@@ -65,10 +86,10 @@ module Api
         want_home = restore_layers.nil? || restore_layers.include?("home")
         want_data = restore_layers.nil? || restore_layers.include?("data")
 
-        if want_home && snap.home_snapshot.present? && BtrfsHelper.btrfs?
+        if want_home && snap.home_snapshot.present? && sandbox.home_persisted? && BtrfsHelper.btrfs?
           manager.ensure_mount_dirs(current_user, sandbox)
-          home_target = "#{SandboxManager::DATA_DIR}/users/#{current_user.name}/home"
-          BtrfsHelper.restore_subvolume(snap.home_snapshot, home_target) rescue nil
+          home_target = manager.sandbox_home_dir(current_user, sandbox)
+          BtrfsHelper.restore_subvolume(snap.home_snapshot, home_target) rescue nil if home_target
         end
 
         if want_data && snap.data_snapshot.present? && BtrfsHelper.btrfs?
@@ -263,10 +284,14 @@ module Api
         id: sandbox.id,
         name: sandbox.name,
         full_name: sandbox.full_name,
+        hostname: sandbox.hostname,
         status: sandbox.status,
         image: sandbox.image,
+        project_name: sandbox.project_name,
         mount_home: sandbox.mount_home,
+        home_path: sandbox.home_path,
         data_path: sandbox.data_path,
+        project_path: sandbox.project_path,
         temporary: sandbox.temporary,
         tailscale: sandbox.tailscale,
         vnc_enabled: sandbox.vnc_enabled,

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,43 @@
+class ProjectsController < ApplicationController
+  def new
+    @project = Current.user.projects.build(
+      image: SandboxManager::DEFAULT_IMAGE,
+      tailscale: Current.user.tailscale_enabled?,
+      vnc_enabled: Current.user.default_vnc_enabled,
+      vnc_geometry: "1280x900",
+      vnc_depth: 24,
+      docker_enabled: Current.user.default_docker_enabled,
+      smb_enabled: Current.user.default_smb_enabled && Current.user.tailscale_enabled? && Current.user.smb_password.present?,
+      ssh_start_tmux: Current.user.default_ssh_start_tmux
+    )
+    authorize @project
+  end
+
+  def create
+    @project = Current.user.projects.build(project_params)
+    authorize @project
+
+    if @project.save
+      redirect_to new_sandbox_path, notice: "Project #{@project.name} created."
+    else
+      flash.now[:alert] = @project.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @project = policy_scope(Project).find(params[:id])
+    authorize @project
+    @project.destroy!
+    redirect_to new_sandbox_path, notice: "Project deleted."
+  end
+
+  private
+
+  def project_params
+    params.require(:project).permit(
+      :name, :path, :image, :tailscale, :vnc_enabled, :vnc_geometry,
+      :vnc_depth, :docker_enabled, :smb_enabled, :ssh_start_tmux
+    )
+  end
+end

--- a/app/controllers/sandboxes_controller.rb
+++ b/app/controllers/sandboxes_controller.rb
@@ -7,6 +7,7 @@ class SandboxesController < ApplicationController
     @snapshots = SandboxManager.new.list_snapshots(user: Current.user)
     @btrfs_available = BtrfsHelper.btrfs?
     @defaults = Current.user
+    @projects = Current.user.projects.order(:name)
   end
 
   def show
@@ -47,11 +48,26 @@ class SandboxesController < ApplicationController
 
     from_snapshot_name = params[:snapshot].presence
 
+    project = Current.user.projects.find_by(id: params[:project_id].presence)
+
     image = if from_snapshot_name.present?
       snap = Snapshot.find_by(user: Current.user, name: from_snapshot_name)
       snap&.docker_image || "sc-snap-#{Current.user.name}:#{from_snapshot_name}"
     else
-      params[:image].presence || SandboxManager::DEFAULT_IMAGE
+      params[:image].presence || project&.image || SandboxManager::DEFAULT_IMAGE
+    end
+
+    project_path = params[:project_path].presence
+    mount_home = project.present? ? false : (params[:mount_home] == "1")
+    home_path = project.present? ? project.path : params[:home_path].presence
+    data_path = project.present? ? project.path : (params[:mount_data] == "1" ? (params[:data_path].presence || ".") : nil)
+    project_name = project&.name
+
+    if project_path.present?
+      mount_home = false
+      home_path = project_path
+      data_path = project_path
+      project_name = File.basename(project_path)
     end
 
     # Build sandbox record
@@ -61,15 +77,17 @@ class SandboxesController < ApplicationController
       name: params.require(:name),
       status: "pending",
       image: image,
-      mount_home: params[:mount_home] == "1",
-      data_path: params[:mount_data] == "1" ? (params[:data_path].presence || ".") : nil,
-      tailscale: params[:tailscale] == "1",
-      vnc_enabled: params[:vnc_enabled] != "0",
-      vnc_geometry: Sandbox::VNC_GEOMETRIES.include?(params[:vnc_geometry]) ? params[:vnc_geometry] : "1280x900",
-      vnc_depth: Sandbox::VNC_DEPTHS.include?(params[:vnc_depth].to_i) ? params[:vnc_depth].to_i : 24,
-      docker_enabled: params[:docker_enabled] != "0",
-      smb_enabled: params[:smb_enabled] == "1",
-      ssh_start_tmux: params[:ssh_start_tmux] == "1",
+      project_name: project_name,
+      mount_home: mount_home,
+      home_path: home_path,
+      data_path: data_path,
+      tailscale: project.present? ? project.tailscale : (params[:tailscale] == "1"),
+      vnc_enabled: project.present? ? project.vnc_enabled : (params[:vnc_enabled] != "0"),
+      vnc_geometry: project.present? ? project.vnc_geometry : (Sandbox::VNC_GEOMETRIES.include?(params[:vnc_geometry]) ? params[:vnc_geometry] : "1280x900"),
+      vnc_depth: project.present? ? project.vnc_depth : (Sandbox::VNC_DEPTHS.include?(params[:vnc_depth].to_i) ? params[:vnc_depth].to_i : 24),
+      docker_enabled: project.present? ? project.docker_enabled : (params[:docker_enabled] != "0"),
+      smb_enabled: project.present? ? project.smb_enabled : (params[:smb_enabled] == "1"),
+      ssh_start_tmux: project.present? ? project.ssh_start_tmux : (params[:ssh_start_tmux] == "1"),
       temporary: false
     )
 
@@ -81,11 +99,13 @@ class SandboxesController < ApplicationController
       redirect_to root_path, notice: "Creating sandcastle #{sandbox.name}..."
     else
       @snapshots = SandboxManager.new.list_snapshots(user: Current.user)
+      @projects = Current.user.projects.order(:name)
       flash.now[:alert] = "Failed to create sandbox: #{sandbox.errors.full_messages.join(', ')}"
       render :new, status: :unprocessable_entity
     end
   rescue => e
     @snapshots = SandboxManager.new.list_snapshots(user: Current.user)
+    @projects = Current.user.projects.order(:name)
     flash.now[:alert] = "Failed to create sandbox: #{e.message}"
     render :new, status: :unprocessable_entity
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,49 @@
+class Project < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+  validates :name, format: { with: /\A[a-z][a-z0-9_-]{0,62}\z/, message: "must be lowercase alphanumeric" }
+  validates :path, presence: true
+  validates :image, presence: true
+  validates :vnc_geometry, inclusion: { in: Sandbox::VNC_GEOMETRIES }
+  validates :vnc_depth, inclusion: { in: Sandbox::VNC_DEPTHS }
+  validate :validate_path
+  validate :smb_prerequisites, if: -> { smb_enabled? }
+
+  before_validation :normalize_path
+
+  def apply_to_sandbox(sandbox)
+    sandbox.mount_home = false
+    sandbox.home_path = path
+    sandbox.data_path = path
+    sandbox.image = image
+    sandbox.tailscale = tailscale
+    sandbox.vnc_enabled = vnc_enabled
+    sandbox.vnc_geometry = vnc_geometry
+    sandbox.vnc_depth = vnc_depth
+    sandbox.docker_enabled = docker_enabled
+    sandbox.smb_enabled = smb_enabled
+    sandbox.ssh_start_tmux = ssh_start_tmux
+    sandbox
+  end
+
+  private
+
+  def normalize_path
+    self.path = path.to_s.strip.chomp("/")
+    self.path = nil if path.blank?
+  end
+
+  def validate_path
+    return if path.blank?
+    errors.add(:path, "must be relative") and return if path.start_with?("/")
+    if path == "." || path.split("/").any? { |seg| seg.blank? || seg == "." || seg == ".." }
+      errors.add(:path, "must be a subdir without .., ., or empty segments")
+    end
+  end
+
+  def smb_prerequisites
+    errors.add(:smb_enabled, "requires Tailscale to be enabled") unless user&.tailscale_enabled?
+    errors.add(:smb_enabled, "requires an SMB password to be set in Settings") unless user&.smb_password.present?
+  end
+end

--- a/app/models/sandbox.rb
+++ b/app/models/sandbox.rb
@@ -17,6 +17,13 @@ class Sandbox < ApplicationRecord
   validates :vnc_geometry, inclusion: { in: VNC_GEOMETRIES }
   validates :vnc_depth, inclusion: { in: VNC_DEPTHS }
   validate :smb_prerequisites, if: -> { smb_enabled? }
+  validate :validate_data_path
+  validate :validate_home_path
+  validate :validate_home_mount_options
+  validate :validate_project_name
+
+  before_validation :normalize_mount_paths
+  before_validation :normalize_project_name
 
   scope :active, -> { where.not(status: %w[destroyed archived]) }
   scope :archived, -> { where(status: "archived") }
@@ -29,6 +36,11 @@ class Sandbox < ApplicationRecord
 
   def full_name
     "#{user.name}-#{name}"
+  end
+
+  def hostname
+    return name if project_name.blank?
+    "#{name}-#{project_name}"
   end
 
   def connect_command
@@ -45,6 +57,15 @@ class Sandbox < ApplicationRecord
 
   def smb_enabled?
     smb_enabled
+  end
+
+  def home_persisted?
+    mount_home? || home_path.present?
+  end
+
+  def project_path
+    return unless home_path.present? && data_path.present?
+    home_path == data_path ? home_path : nil
   end
 
   # Whether SSH logins should auto-attach to a tmux session. Per-sandbox
@@ -96,6 +117,57 @@ class Sandbox < ApplicationRecord
   end
 
   private
+
+  def normalize_mount_paths
+    self.data_path = normalize_mount_path(data_path, allow_root: true)
+    self.home_path = normalize_mount_path(home_path, allow_root: false)
+  end
+
+  def normalize_project_name
+    self.project_name = project_name.to_s.strip.presence
+  end
+
+  def normalize_mount_path(value, allow_root:)
+    path = value.to_s.strip.chomp("/")
+    return nil if path.blank?
+    return "." if allow_root && path == "."
+    path
+  end
+
+  def validate_data_path
+    validate_mount_path(:data_path, allow_root: true)
+  end
+
+  def validate_home_path
+    validate_mount_path(:home_path, allow_root: false)
+  end
+
+  def validate_mount_path(attribute, allow_root:)
+    value = public_send(attribute)
+    return if value.blank?
+    return if allow_root && value == "."
+
+    if value.start_with?("/")
+      errors.add(attribute, "must be relative")
+      return
+    end
+
+    if value.split("/").any? { |seg| seg.blank? || seg == "." || seg == ".." }
+      errors.add(attribute, "must not contain .., ., or empty segments")
+    end
+  end
+
+  def validate_home_mount_options
+    return unless mount_home? && home_path.present?
+    errors.add(:home_path, "cannot be combined with full home mount")
+  end
+
+  def validate_project_name
+    return if project_name.blank?
+    unless project_name.match?(/\A[a-z][a-z0-9_-]{0,62}\z/)
+      errors.add(:project_name, "must be lowercase alphanumeric")
+    end
+  end
 
   def smb_prerequisites
     errors.add(:smb_enabled, "requires Tailscale to be enabled") unless user&.tailscale_enabled?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :sandboxes, dependent: :destroy
   has_many :api_tokens, dependent: :destroy
   has_many :oauth_identities, dependent: :destroy
+  has_many :projects, dependent: :destroy
   has_many :injected_files, dependent: :destroy
   has_many :persisted_paths, dependent: :destroy
   has_many :ignored_paths, dependent: :destroy

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -1,0 +1,19 @@
+class ProjectPolicy < ApplicationPolicy
+  def index? = true
+  def show? = owner_only?
+  def create? = true
+  def update? = owner_only?
+  def destroy? = owner_only?
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.where(user:)
+    end
+  end
+
+  private
+
+  def owner_only?
+    record.user_id == user.id
+  end
+end

--- a/app/services/btrfs_helper.rb
+++ b/app/services/btrfs_helper.rb
@@ -173,6 +173,37 @@ class BtrfsHelper
       end
     end
 
+    # Create a BTRFS subvolume for a user's home directory or one of its subdirs
+    def create_user_home_subvolume(username, home_path = nil)
+      create_user_subvolume(username)
+
+      home_dir = if home_path.present?
+        "#{DATA_DIR}/users/#{username}/home/#{home_path}".chomp("/")
+      else
+        "#{DATA_DIR}/users/#{username}/home"
+      end
+
+      if btrfs?
+        if subvolume?(home_dir)
+          Rails.logger.debug("Home directory is already a BTRFS subvolume: #{home_dir}")
+          ensure_owned(home_dir)
+          return true
+        end
+
+        if Dir.exist?(home_dir)
+          Rails.logger.info("Fixing ownership of existing home directory: #{home_dir}")
+          ensure_owned(home_dir)
+          return false
+        end
+
+        create_subvolume(home_dir)
+      else
+        FileUtils.mkdir_p(home_dir) unless Dir.exist?(home_dir)
+        ensure_owned(home_dir)
+        false
+      end
+    end
+
     # Check if a path is a BTRFS subvolume
     def subvolume?(path)
       return false unless Dir.exist?(path)

--- a/app/services/sandbox_manager.rb
+++ b/app/services/sandbox_manager.rb
@@ -5,13 +5,14 @@ class SandboxManager
 
   class Error < StandardError; end
 
-  def create(user:, name:, image: DEFAULT_IMAGE, tailscale: false, mount_home: false, data_path: nil, temporary: false)
+  def create(user:, name:, image: DEFAULT_IMAGE, tailscale: false, mount_home: false, home_path: nil, data_path: nil, temporary: false)
     # Build sandbox record (not saved yet)
     sandbox = user.sandboxes.build(
       name: name,
       image: image,
       status: "pending",
       mount_home: mount_home,
+      home_path: home_path,
       data_path: data_path,
       temporary: temporary
     )
@@ -56,7 +57,7 @@ class SandboxManager
     container = Docker::Container.create(
       "name" => sandbox.full_name,
       "Image" => sandbox.image,
-      "Hostname" => sandbox.full_name,
+      "Hostname" => sandbox.hostname,
       "Env" => container_env(user, sandbox),
       "Labels" => { "sandcastle.sandbox" => "true" },
       "HostConfig" => {
@@ -129,8 +130,10 @@ class SandboxManager
     # Ensure user base directory is writable (may be root-owned from previous install)
     ensure_dir("#{DATA_DIR}/users/#{user.name}")
 
-    if sandbox.mount_home
-      dir = "#{DATA_DIR}/users/#{user.name}/home"
+    home_dir = sandbox_home_dir(user, sandbox)
+    if home_dir
+      BtrfsHelper.create_user_home_subvolume(user.name, sandbox.home_path) if sandbox.home_persisted?
+      dir = home_dir
       ensure_dir(dir)
       prepare_bind_mount(dir)
     end
@@ -143,7 +146,7 @@ class SandboxManager
       prepare_bind_mount(dir)
     end
     # Per-user persisted paths (e.g. .claude, .codex) — only when full home isn't mounted
-    if !sandbox.mount_home
+    if !sandbox.home_persisted?
       user.persisted_paths.find_each do |pp|
         dir = "#{DATA_DIR}/users/#{user.name}/persisted/#{pp.path}"
         ensure_dir(dir)
@@ -433,10 +436,10 @@ class SandboxManager
     end
 
     # ── Home layer (BTRFS only) ───────────────────────────────────────────────
-    if requested_layers.include?("home") && sandbox.mount_home? && BtrfsHelper.btrfs?
-      home_src  = "#{DATA_DIR}/users/#{user.name}/home"
+    if requested_layers.include?("home") && sandbox.home_persisted? && BtrfsHelper.btrfs?
+      home_src = sandbox_home_dir(user, sandbox)
       home_dest = "#{DATA_DIR}/snapshots/#{user.name}/#{name}/home"
-      if Dir.exist?(home_src)
+      if home_src && Dir.exist?(home_src)
         BtrfsHelper.snapshot_subvolume(home_src, home_dest)
         snap.home_snapshot = home_dest
         snap.home_size     = BtrfsHelper.subvolume_size(home_dest)
@@ -593,9 +596,9 @@ class SandboxManager
 
     # ── Restore home directory ────────────────────────────────────────────────
     if restore_home
-      home_target = "#{DATA_DIR}/users/#{user.name}/home"
+      home_target = sandbox_home_dir(user, sandbox)
       begin
-        BtrfsHelper.restore_subvolume(snap.home_snapshot, home_target)
+        BtrfsHelper.restore_subvolume(snap.home_snapshot, home_target) if home_target
       rescue BtrfsHelper::Error => e
         Rails.logger.warn("Could not restore home snapshot: #{e.message}")
       end
@@ -811,7 +814,8 @@ class SandboxManager
     env << "SANDCASTLE_VNC_DEPTH=#{sandbox.vnc_depth}"
     env << "SANDCASTLE_DOCKER_ENABLED=#{sandbox.docker_enabled? ? '1' : '0'}"
     env << "SANDCASTLE_SMB_ENABLED=#{sandbox.smb_enabled? ? '1' : '0'}"
-    env << "SANDCASTLE_HOME_PERSISTED=#{sandbox.mount_home ? '1' : '0'}"
+    env << "SANDCASTLE_HOME_PERSISTED=#{sandbox.home_persisted? ? '1' : '0'}"
+    env << "SANDCASTLE_HOME_PATH=#{sandbox.home_path}" if sandbox.home_path.present?
     env << "SANDCASTLE_DATA_PERSISTED=#{sandbox.data_path.present? ? '1' : '0'}"
     env << "SANDCASTLE_DATA_PATH=#{sandbox.data_path}" if sandbox.data_path.present?
     env << "SANDCASTLE_SSH_START_TMUX=#{sandbox.effective_ssh_start_tmux? ? '1' : '0'}"
@@ -925,20 +929,27 @@ class SandboxManager
 
   def volume_binds(user, sandbox)
     binds = []
-    if sandbox.mount_home
-      binds << "#{DATA_DIR}/users/#{user.name}/home:/home/#{user.name}"
+    if (home_dir = sandbox_home_dir(user, sandbox))
+      binds << "#{home_dir}:/home/#{user.name}"
     end
     if sandbox.data_path.present?
       host_path = "#{DATA_DIR}/users/#{user.name}/data/#{sandbox.data_path}".chomp("/")
       binds << "#{host_path}:/persisted"
     end
     # Per-user persisted dotdirs (Claude/Codex auth, etc.) — only when full home isn't mounted
-    if !sandbox.mount_home
+    if !sandbox.home_persisted?
       user.persisted_paths.find_each do |pp|
         host_path = "#{DATA_DIR}/users/#{user.name}/persisted/#{pp.path}"
         binds << "#{host_path}:/home/#{user.name}/#{pp.path}"
       end
     end
     binds
+  end
+
+  def sandbox_home_dir(user, sandbox)
+    return "#{DATA_DIR}/users/#{user.name}/home" if sandbox.mount_home?
+    return if sandbox.home_path.blank?
+
+    "#{DATA_DIR}/users/#{user.name}/home/#{sandbox.home_path}".chomp("/")
   end
 end

--- a/app/views/dashboard/_sandbox.html.erb
+++ b/app/views/dashboard/_sandbox.html.erb
@@ -55,18 +55,23 @@
           TEMP
         </span>
       <% end %>
-      <% if sandbox.mount_home? %>
+      <% if sandbox.project_path.present? %>
+        <span class="text-xs font-medium text-emerald-700 bg-emerald-100 px-1.5 py-0.5 rounded inline-flex items-center gap-0.5">
+          project:<%= sandbox.project_path %>
+        </span>
+      <% end %>
+      <% if sandbox.home_persisted? %>
         <% if sandbox.smb_enabled? && local_assigns[:tailscale_ip].present? %>
           <a href="smb://<%= sandbox.user.name %>:<%= sandbox.user.smb_password %>@<%= local_assigns[:tailscale_ip] %>/home"
              title="Mount home via SMB"
              class="text-xs font-medium text-orange-700 bg-orange-100 border border-orange-300 px-1.5 py-0.5 rounded inline-flex items-center gap-0.5 hover:bg-orange-200 hover:border-orange-400 transition-colors cursor-pointer">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3"><path fill-rule="evenodd" d="M3.75 3A1.75 1.75 0 0 0 2 4.75v3.26a3.235 3.235 0 0 1 1.75-.51h12.5c.644 0 1.245.188 1.75.51V6.75A1.75 1.75 0 0 0 16.25 5h-4.836a.25.25 0 0 1-.177-.073L9.823 3.513A1.75 1.75 0 0 0 8.586 3H3.75ZM3.75 9A1.75 1.75 0 0 0 2 10.75v4.5c0 .966.784 1.75 1.75 1.75h12.5A1.75 1.75 0 0 0 18 15.25v-4.5A1.75 1.75 0 0 0 16.25 9H3.75Z" clip-rule="evenodd" /></svg>
-            home
+            home<%= ":#{sandbox.home_path}" if sandbox.home_path.present? %>
           </a>
         <% else %>
           <span class="text-xs font-medium text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded inline-flex items-center gap-0.5">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3"><path fill-rule="evenodd" d="M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z" clip-rule="evenodd" /></svg>
-            home
+            home<%= ":#{sandbox.home_path}" if sandbox.home_path.present? %>
           </span>
         <% end %>
       <% end %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,0 +1,101 @@
+<% content_for(:title) { "Create Project" } %>
+
+<div class="max-w-3xl mx-auto px-4 py-8">
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold text-gray-900">Create Project</h1>
+    <p class="text-gray-500 mt-1">Save a reusable sandbox preset with a scoped home and persisted path.</p>
+  </div>
+
+  <%= form_with model: @project, class: "space-y-6" do |form| %>
+    <div class="bg-white rounded-lg border border-gray-200 p-6 space-y-4">
+      <h2 class="text-lg font-semibold text-gray-900">Project</h2>
+
+      <div>
+        <%= form.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.text_field :name, required: true, pattern: "[a-z][a-z0-9_\\-]*", maxlength: 63, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <div>
+        <%= form.label :path, "Project Subdir", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.text_field :path, required: true, placeholder: "e.g., projects/myapp", class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+        <p class="mt-1 text-xs text-gray-500">This subdir will be mounted as both <code class="bg-gray-100 px-1 rounded font-mono">$HOME</code> and <code class="bg-gray-100 px-1 rounded font-mono">/persisted</code> for sandboxes created from the project.</p>
+      </div>
+
+      <div>
+        <%= form.label :image, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.text_field :image, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+    </div>
+
+    <div class="bg-white rounded-lg border border-gray-200 p-6 space-y-4">
+      <h2 class="text-lg font-semibold text-gray-900">Defaults</h2>
+
+      <label class="flex items-start gap-3 cursor-pointer">
+        <%= form.check_box :tailscale, class: "mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        <div class="flex-1">
+          <div class="text-sm font-medium text-gray-900">Connect to Tailscale</div>
+        </div>
+      </label>
+
+      <label class="flex items-start gap-3 cursor-pointer">
+        <%= form.check_box :docker_enabled, class: "mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        <div class="flex-1">
+          <div class="text-sm font-medium text-gray-900">Start Docker daemon</div>
+        </div>
+      </label>
+
+      <label class="flex items-start gap-3 cursor-pointer">
+        <%= form.check_box :ssh_start_tmux, class: "mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        <div class="flex-1">
+          <div class="text-sm font-medium text-gray-900">Start tmux on SSH login</div>
+        </div>
+      </label>
+
+      <label class="flex items-start gap-3 cursor-pointer">
+        <%= form.check_box :vnc_enabled, id: "project_vnc_enabled", class: "mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        <div class="flex-1">
+          <div class="text-sm font-medium text-gray-900">Enable VNC display</div>
+        </div>
+      </label>
+
+      <div id="project_vnc_options" class="grid grid-cols-2 gap-3">
+        <div>
+          <%= form.label :vnc_geometry, "Resolution", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= form.select :vnc_geometry, options_for_select(Sandbox::VNC_GEOMETRIES, @project.vnc_geometry), {}, class: "w-full px-3 py-2 border border-gray-300 rounded-lg" %>
+        </div>
+        <div>
+          <%= form.label :vnc_depth, "Color depth", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= form.select :vnc_depth, options_for_select(Sandbox::VNC_DEPTHS, @project.vnc_depth), {}, class: "w-full px-3 py-2 border border-gray-300 rounded-lg" %>
+        </div>
+      </div>
+
+      <% smb_ready = Current.user.tailscale_enabled? && Current.user.smb_password.present? %>
+      <label class="flex items-start gap-3 <%= smb_ready ? 'cursor-pointer' : 'opacity-50' %>">
+        <%= form.check_box :smb_enabled, disabled: !smb_ready, class: "mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        <div class="flex-1">
+          <div class="text-sm font-medium text-gray-900">Enable SMB file sharing</div>
+        </div>
+      </label>
+    </div>
+
+    <div class="flex items-center justify-between pt-4">
+      <%= link_to "Back", new_sandbox_path, class: "text-gray-600 hover:text-gray-900" %>
+      <%= form.submit "Create Project", class: "px-6 py-2.5 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:ring-4 focus:ring-blue-200" %>
+    </div>
+  <% end %>
+</div>
+
+<script>
+(function() {
+  var vncCheckbox = document.getElementById("project_vnc_enabled");
+  var vncOptions = document.getElementById("project_vnc_options");
+  if (!vncCheckbox || !vncOptions) return;
+
+  function toggleVnc() {
+    vncOptions.style.display = vncCheckbox.checked ? "" : "none";
+  }
+
+  vncCheckbox.addEventListener("change", toggleVnc);
+  toggleVnc();
+})();
+</script>

--- a/app/views/sandboxes/new.html.erb
+++ b/app/views/sandboxes/new.html.erb
@@ -67,14 +67,47 @@
     <div class="bg-white rounded-lg border border-gray-200 p-6 space-y-4">
       <h2 class="text-lg font-semibold text-gray-900">Storage Options</h2>
 
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex-1">
+          <%= form.label :project_id, "Project Preset", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= form.select :project_id,
+                options_for_select([["None", ""]] + @projects.map { |project| ["#{project.name} (#{project.path})", project.id] }),
+                {},
+                id: "sandbox_project_id",
+                class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+          <p class="mt-1 text-xs text-gray-500">Pick a saved project to reuse its scoped home/data path and all sandbox defaults.</p>
+        </div>
+        <div class="pt-6">
+          <%= link_to "New Project", new_project_path, class: "inline-flex px-3 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200" %>
+        </div>
+      </div>
+
+      <div>
+        <%= form.label :project_path, "Project Subdir", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.text_field :project_path,
+              placeholder: "e.g., projects/myapp",
+              id: "sandbox_project_path",
+              class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+        <p class="mt-1 text-xs text-gray-500">Creates a project-scoped sandbox by mounting this subdir as both <code class="bg-gray-100 px-1 rounded font-mono">$HOME</code> and <code class="bg-gray-100 px-1 rounded font-mono">/persisted</code>.</p>
+      </div>
+
       <div class="space-y-3">
         <label class="flex items-start gap-3 cursor-pointer">
-          <%= form.check_box :mount_home, checked: @defaults.default_mount_home, class: "mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+          <%= form.check_box :mount_home, checked: @defaults.default_mount_home, id: "sandbox_mount_home", class: "mt-1 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
           <div class="flex-1">
             <div class="text-sm font-medium text-gray-900">Mount persistent home directory</div>
             <p class="text-xs text-gray-500">Your home directory (~/) will persist across all sandboxes</p>
           </div>
         </label>
+
+        <div id="home_path_row">
+          <%= form.label :home_path, "Home Subdir (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= form.text_field :home_path,
+                placeholder: "e.g., projects/myapp",
+                id: "sandbox_home_path",
+                class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+          <p class="mt-1 text-xs text-gray-500">Mount only this subdir of your persisted home as <code class="bg-gray-100 px-1 rounded font-mono">$HOME</code>. Leave empty to disable.</p>
+        </div>
 
         <label class="flex items-start gap-3 cursor-pointer">
           <%= form.check_box :mount_data, id: "sandbox_mount_data", checked: @defaults.default_data_path.present?,
@@ -220,12 +253,62 @@
 
   var mountDataCheckbox = document.getElementById("sandbox_mount_data");
   var dataPathRow = document.getElementById("data_path_row");
+  var mountHomeCheckbox = document.getElementById("sandbox_mount_home");
+  var homePathRow = document.getElementById("home_path_row");
+  var projectSelect = document.getElementById("sandbox_project_id");
+  var projectPathInput = document.getElementById("sandbox_project_path");
+  var homePathInput = document.getElementById("sandbox_home_path");
+  var projectPresetMode = false;
+  var toggleDataPath = function() {};
+  var toggleHomePath = function() {};
+  var syncProjectMode = function() {};
   if (mountDataCheckbox && dataPathRow) {
-    function toggleDataPath() {
-      dataPathRow.style.display = mountDataCheckbox.checked ? "" : "none";
-    }
+    toggleDataPath = function() {
+      var projectMode = projectPathInput && projectPathInput.value.trim() !== "";
+      dataPathRow.style.display = mountDataCheckbox.checked && !projectMode && !projectPresetMode ? "" : "none";
+    };
     mountDataCheckbox.addEventListener("change", toggleDataPath);
     toggleDataPath();
+  }
+  if (mountHomeCheckbox && homePathRow) {
+    toggleHomePath = function() {
+      var projectMode = projectPathInput && projectPathInput.value.trim() !== "";
+      homePathRow.style.display = (!mountHomeCheckbox.checked && !projectMode && !projectPresetMode) ? "" : "none";
+    };
+    mountHomeCheckbox.addEventListener("change", toggleHomePath);
+    toggleHomePath();
+  }
+  if (projectPathInput) {
+    syncProjectMode = function() {
+      var projectMode = projectPathInput.value.trim() !== "";
+      if (mountHomeCheckbox) {
+        mountHomeCheckbox.disabled = projectMode || projectPresetMode;
+      }
+      if (mountDataCheckbox) {
+        mountDataCheckbox.disabled = projectMode || projectPresetMode;
+      }
+      if (homePathInput) {
+        homePathInput.disabled = projectMode || projectPresetMode;
+      }
+      if (projectMode) {
+        if (mountHomeCheckbox) mountHomeCheckbox.checked = false;
+        if (mountDataCheckbox) mountDataCheckbox.checked = false;
+        if (homePathInput) homePathInput.value = "";
+      }
+      toggleHomePath();
+      toggleDataPath();
+    };
+    projectPathInput.addEventListener("input", syncProjectMode);
+    syncProjectMode();
+  }
+  if (projectSelect) {
+    projectSelect.addEventListener("change", function() {
+      projectPresetMode = projectSelect.value !== "";
+      syncProjectMode();
+      toggleHomePath();
+      toggleDataPath();
+    });
+    projectPresetMode = projectSelect.value !== "";
   }
 
   var vncCheckbox = document.getElementById("sandbox_vnc_enabled");
@@ -235,6 +318,7 @@
       vncOptionsRow.style.display = vncCheckbox.checked ? "" : "none";
     }
     vncCheckbox.addEventListener("change", toggleVncOptions);
+    toggleVncOptions();
   }
 })();
 </script>

--- a/app/views/sandboxes/show.html.erb
+++ b/app/views/sandboxes/show.html.erb
@@ -139,6 +139,9 @@
         <div class="space-y-1 text-xs font-mono bg-gray-50 border border-gray-200 rounded p-3">
           <div><span class="text-gray-500">macOS:</span> smb://&lt;tailscale-ip&gt;/home</div>
           <div><span class="text-gray-500">Windows:</span> \\&lt;tailscale-ip&gt;\home</div>
+          <% if @sandbox.home_persisted? %>
+            <div><span class="text-gray-500">home:</span> smb://&lt;tailscale-ip&gt;/home <%= "(#{@sandbox.home_path})" if @sandbox.home_path.present? %></div>
+          <% end %>
           <% if @sandbox.data_path.present? %>
             <div><span class="text-gray-500">persisted:</span> smb://&lt;tailscale-ip&gt;/persisted</div>
           <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,10 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Use STDOUT in tests so containerized runs do not depend on bind-mounted
+  # log file ownership matching the in-container UID/GID.
+  config.logger = ActiveSupport::TaggedLogging.logger($stdout)
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
     end
     resources :routes, only: [ :create, :destroy ]
   end
+  resources :projects, only: [ :new, :create, :destroy ]
 
   resources :snapshots, only: [ :index, :destroy ], param: :name do
     member do
@@ -117,6 +118,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     get "archived_sandboxes", to: "sandboxes#archived_index"
+    resources :projects, only: [ :index, :show, :create, :destroy ]
     resources :sandboxes do
       member do
         post :start

--- a/db/migrate/20260505120000_add_home_path_to_sandboxes.rb
+++ b/db/migrate/20260505120000_add_home_path_to_sandboxes.rb
@@ -1,0 +1,5 @@
+class AddHomePathToSandboxes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :sandboxes, :home_path, :string
+  end
+end

--- a/db/migrate/20260505123000_create_projects.rb
+++ b/db/migrate/20260505123000_create_projects.rb
@@ -1,0 +1,20 @@
+class CreateProjects < ActiveRecord::Migration[8.0]
+  def change
+    create_table :projects do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :path, null: false
+      t.string :image, null: false, default: "ghcr.io/thieso2/sandcastle-sandbox:latest"
+      t.boolean :tailscale, null: false, default: false
+      t.boolean :vnc_enabled, null: false, default: true
+      t.string :vnc_geometry, null: false, default: "1280x900"
+      t.integer :vnc_depth, null: false, default: 24
+      t.boolean :docker_enabled, null: false, default: true
+      t.boolean :smb_enabled, null: false, default: false
+      t.boolean :ssh_start_tmux, null: false, default: true
+      t.timestamps
+    end
+
+    add_index :projects, [ :user_id, :name ], unique: true
+  end
+end

--- a/db/migrate/20260505130000_add_project_name_to_sandboxes.rb
+++ b/db/migrate/20260505130000_add_project_name_to_sandboxes.rb
@@ -1,0 +1,5 @@
+class AddProjectNameToSandboxes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :sandboxes, :project_name, :string
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -106,6 +106,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
     t.index ["user_id"], name: "index_persisted_paths_on_user_id"
   end
 
+  create_table "projects", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "docker_enabled", default: true, null: false
+    t.string "image", default: "ghcr.io/thieso2/sandcastle-sandbox:latest", null: false
+    t.string "name", null: false
+    t.string "path", null: false
+    t.boolean "smb_enabled", default: false, null: false
+    t.boolean "ssh_start_tmux", default: true, null: false
+    t.boolean "tailscale", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.integer "vnc_depth", default: 24, null: false
+    t.boolean "vnc_enabled", default: true, null: false
+    t.string "vnc_geometry", default: "1280x900", null: false
+    t.index ["user_id", "name"], name: "index_projects_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_projects_on_user_id"
+  end
+
   create_table "routes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "domain"
@@ -125,6 +143,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
     t.datetime "created_at", null: false
     t.string "data_path"
     t.boolean "docker_enabled", default: true, null: false
+    t.string "home_path"
     t.string "image", default: "ghcr.io/thieso2/sandcastle-sandbox:latest", null: false
     t.datetime "image_built_at"
     t.string "image_id"
@@ -135,6 +154,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
     t.boolean "mount_home", default: false, null: false
     t.string "name", null: false
     t.boolean "persistent_volume", default: false, null: false
+    t.string "project_name"
     t.boolean "smb_enabled", default: false, null: false
     t.integer "ssh_port"
     t.string "status", default: "pending", null: false
@@ -363,6 +383,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
   add_foreign_key "invites", "users", column: "invited_by_id"
   add_foreign_key "oauth_identities", "users"
   add_foreign_key "persisted_paths", "users"
+  add_foreign_key "projects", "users"
   add_foreign_key "routes", "sandboxes"
   add_foreign_key "sandboxes", "users"
   add_foreign_key "sessions", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -106,6 +106,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
     t.index ["user_id"], name: "index_persisted_paths_on_user_id"
   end
 
+  create_table "projects", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "docker_enabled", default: true, null: false
+    t.string "image", default: "ghcr.io/thieso2/sandcastle-sandbox:latest", null: false
+    t.string "name", null: false
+    t.string "path", null: false
+    t.boolean "smb_enabled", default: false, null: false
+    t.boolean "ssh_start_tmux", default: true, null: false
+    t.boolean "tailscale", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.integer "vnc_depth", default: 24, null: false
+    t.boolean "vnc_enabled", default: true, null: false
+    t.string "vnc_geometry", default: "1280x900", null: false
+    t.index ["user_id", "name"], name: "index_projects_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_projects_on_user_id"
+  end
+
   create_table "routes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "domain"
@@ -125,6 +143,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
     t.datetime "created_at", null: false
     t.string "data_path"
     t.boolean "docker_enabled", default: true, null: false
+    t.string "home_path"
     t.string "image", default: "ghcr.io/thieso2/sandcastle-sandbox:latest", null: false
     t.datetime "image_built_at"
     t.string "image_id"
@@ -135,6 +154,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
     t.boolean "mount_home", default: false, null: false
     t.string "name", null: false
     t.boolean "persistent_volume", default: false, null: false
+    t.string "project_name"
     t.boolean "smb_enabled", default: false, null: false
     t.integer "ssh_port"
     t.boolean "ssh_start_tmux"
@@ -244,6 +264,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_230000) do
   add_foreign_key "invites", "users", column: "invited_by_id"
   add_foreign_key "oauth_identities", "users"
   add_foreign_key "persisted_paths", "users"
+  add_foreign_key "projects", "users"
   add_foreign_key "routes", "sandboxes"
   add_foreign_key "sandboxes", "users"
   add_foreign_key "sessions", "users"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -71,7 +71,7 @@ services:
               keyFile: /certs/key.pem
         EOFTLS
         fi
-        chown -R ${SANDCASTLE_UID:-220568}:${SANDCASTLE_GID:-220568} /data
+        chown -R ${SANDCASTLE_UID:-22051}:${SANDCASTLE_GID:-22051} /data
 
   postgres:
     image: postgres:18
@@ -95,7 +95,7 @@ services:
     image: busybox
     volumes:
       - sandcastle-data:/data
-    command: sh -c "mkdir -p /data/users /data/sandboxes && chown -R ${SANDCASTLE_UID:-220568}:${SANDCASTLE_GID:-220568} /data"
+    command: sh -c "mkdir -p /data/users /data/sandboxes && chown -R ${SANDCASTLE_UID:-22051}:${SANDCASTLE_GID:-22051} /data"
 
   web:
     image: sandcastle:dev
@@ -108,8 +108,8 @@ services:
         BUILD_GIT_SHA: ""
         BUILD_GIT_DIRTY: ""
         BUILD_DATE: ""
-        SANDCASTLE_UID: ${SANDCASTLE_UID:-220568}
-        SANDCASTLE_GID: ${SANDCASTLE_GID:-220568}
+        SANDCASTLE_UID: ${SANDCASTLE_UID:-22051}
+        SANDCASTLE_GID: ${SANDCASTLE_GID:-22051}
     container_name: sandcastle-web
     group_add:
       - "${DOCKER_GID:-0}"
@@ -173,8 +173,8 @@ services:
         BUILD_GIT_SHA: ""
         BUILD_GIT_DIRTY: ""
         BUILD_DATE: ""
-        SANDCASTLE_UID: ${SANDCASTLE_UID:-220568}
-        SANDCASTLE_GID: ${SANDCASTLE_GID:-220568}
+        SANDCASTLE_UID: ${SANDCASTLE_UID:-22051}
+        SANDCASTLE_GID: ${SANDCASTLE_GID:-22051}
     container_name: sandcastle-worker
     group_add:
       - "${DOCKER_GID:-0}"
@@ -221,8 +221,8 @@ services:
       target: development
       network: host
       args:
-        SANDCASTLE_UID: ${SANDCASTLE_UID:-220568}
-        SANDCASTLE_GID: ${SANDCASTLE_GID:-220568}
+        SANDCASTLE_UID: ${SANDCASTLE_UID:-22051}
+        SANDCASTLE_GID: ${SANDCASTLE_GID:-22051}
     volumes:
       - .:/rails
       - bundle-data:/usr/local/bundle

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -40,7 +40,7 @@ services:
           level: INFO
         EOF
         fi
-        chown -R 220568:220568 /data
+        chown -R ${SANDCASTLE_UID:-22051}:${SANDCASTLE_GID:-22051} /data
 
   postgres:
     image: postgres:18
@@ -62,7 +62,7 @@ services:
     image: busybox
     volumes:
       - sandcastle-data:/data
-    command: sh -c "mkdir -p /data/users /data/sandboxes && chown -R 220568:220568 /data"
+    command: sh -c "mkdir -p /data/users /data/sandboxes && chown -R ${SANDCASTLE_UID:-22051}:${SANDCASTLE_GID:-22051} /data"
 
   web:
     image: sandcastle:local
@@ -73,6 +73,8 @@ services:
         BUILD_GIT_SHA: "${BUILD_GIT_SHA:-local}"
         BUILD_GIT_DIRTY: "${BUILD_GIT_DIRTY:-false}"
         BUILD_DATE: "${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+        SANDCASTLE_UID: ${SANDCASTLE_UID:-22051}
+        SANDCASTLE_GID: ${SANDCASTLE_GID:-22051}
     container_name: sandcastle-web
     command: ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "80"]
     group_add:
@@ -115,6 +117,8 @@ services:
         BUILD_GIT_SHA: "${BUILD_GIT_SHA:-local}"
         BUILD_GIT_DIRTY: "${BUILD_GIT_DIRTY:-false}"
         BUILD_DATE: "${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+        SANDCASTLE_UID: ${SANDCASTLE_UID:-22051}
+        SANDCASTLE_GID: ${SANDCASTLE_GID:-22051}
     container_name: sandcastle-worker
     command: ["bundle", "exec", "rake", "solid_queue:start"]
     group_add:

--- a/mise.toml
+++ b/mise.toml
@@ -35,7 +35,8 @@ export DEV_HOST="${DEV_HOST:-localhost}"
 # Pick a UID/GID for the in-container sandcastle user. Default to the host
 # user's IDs so bind-mounted source files stay owned by you on disk. If the
 # outer environment uses a restricted user namespace (e.g. Sysbox), the
-# production default of 220568 would exceed the range and fail with EINVAL
+# the old production default of 220568 can exceed the supported range and fail
+# with EINVAL on some Docker volume backends
 # on chown/setgroups — the host UID is always within range.
 if [ -z "${SANDCASTLE_UID:-}" ]; then
   if [ -r /proc/self/uid_map ]; then
@@ -47,8 +48,8 @@ if [ -z "${SANDCASTLE_UID:-}" ]; then
     fi
   fi
 fi
-export SANDCASTLE_UID="${SANDCASTLE_UID:-220568}"
-export SANDCASTLE_GID="${SANDCASTLE_GID:-220568}"
+export SANDCASTLE_UID="${SANDCASTLE_UID:-22051}"
+export SANDCASTLE_GID="${SANDCASTLE_GID:-22051}"
 
 echo "Starting development environment with live reload..."
 echo "  DEV_HOST=${DEV_HOST}  DOCKER_GID=${DOCKER_GID}  SANDCASTLE_UID=${SANDCASTLE_UID}"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,12 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  include SessionTestHelper
+  include ActiveJob::TestHelper
+
+  if ENV["SYSTEM_TEST_DRIVER"] == "rack_test"
+    driven_by :rack_test
+  else
+    driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  end
 end

--- a/test/jobs/sandbox_destroy_job_test.rb
+++ b/test/jobs/sandbox_destroy_job_test.rb
@@ -56,7 +56,7 @@ class SandboxDestroyJobTest < ActiveJob::TestCase
     @sandbox.update!(status: "archived", archived_at: Time.current)
 
     perform_enqueued_jobs do
-      SandboxDestroyJob.perform_later(sandbox_id: @sandbox.id)
+      SandboxDestroyJob.perform_later(sandbox_id: @sandbox.id, archive: true)
     end
 
     @sandbox.reload

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ProjectTest < ActiveSupport::TestCase
+  setup { @user = users(:one) }
+
+  test "valid record" do
+    project = @user.projects.build(
+      name: "myproj",
+      path: "projects/myproj",
+      image: SandboxManager::DEFAULT_IMAGE,
+      docker_enabled: true,
+      vnc_enabled: true,
+      vnc_geometry: "1280x900",
+      vnc_depth: 24,
+      ssh_start_tmux: true
+    )
+
+    assert project.valid?, project.errors.full_messages.inspect
+  end
+
+  test "rejects root or traversal paths" do
+    assert_not @user.projects.build(name: "bad1", path: ".", image: SandboxManager::DEFAULT_IMAGE).valid?
+    assert_not @user.projects.build(name: "bad2", path: "../escape", image: SandboxManager::DEFAULT_IMAGE).valid?
+    assert_not @user.projects.build(name: "bad3", path: "/abs", image: SandboxManager::DEFAULT_IMAGE).valid?
+  end
+
+  test "apply_to_sandbox scopes home and persisted to project path" do
+    project = @user.projects.create!(
+      name: "myproj",
+      path: "projects/myproj",
+      image: "ghcr.io/thieso2/sandcastle-sandbox:latest",
+      docker_enabled: false,
+      vnc_enabled: false,
+      tailscale: true,
+      smb_enabled: false,
+      ssh_start_tmux: false
+    )
+    sandbox = @user.sandboxes.build(name: "box", status: "pending", image: SandboxManager::DEFAULT_IMAGE)
+
+    project.apply_to_sandbox(sandbox)
+
+    assert_not sandbox.mount_home
+    assert_equal "projects/myproj", sandbox.home_path
+    assert_equal "projects/myproj", sandbox.data_path
+    assert_equal project.image, sandbox.image
+    assert_equal project.docker_enabled, sandbox.docker_enabled
+  end
+end

--- a/test/models/sandbox_test.rb
+++ b/test/models/sandbox_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class SandboxTest < ActiveSupport::TestCase
+  setup { @user = users(:one) }
+
+  test "rejects combining full home and home_path" do
+    sandbox = @user.sandboxes.build(
+      name: "testbox",
+      status: "pending",
+      image: SandboxManager::DEFAULT_IMAGE,
+      mount_home: true,
+      home_path: "projects/demo"
+    )
+
+    assert_not sandbox.valid?
+    assert_includes sandbox.errors[:home_path], "cannot be combined with full home mount"
+  end
+
+  test "derives project_path when home and data paths match" do
+    sandbox = @user.sandboxes.build(
+      name: "testbox",
+      status: "pending",
+      image: SandboxManager::DEFAULT_IMAGE,
+      home_path: "projects/demo",
+      data_path: "projects/demo"
+    )
+
+    assert sandbox.valid?, sandbox.errors.full_messages.inspect
+    assert_equal "projects/demo", sandbox.project_path
+  end
+
+  test "hostname includes project name when present" do
+    sandbox = @user.sandboxes.build(
+      name: "testbox",
+      project_name: "alpha",
+      status: "pending",
+      image: SandboxManager::DEFAULT_IMAGE
+    )
+
+    assert_equal "testbox-alpha", sandbox.hostname
+    assert_equal "alice-testbox", sandbox.full_name
+  end
+end

--- a/test/services/sandbox_manager_inject_files_test.rb
+++ b/test/services/sandbox_manager_inject_files_test.rb
@@ -84,4 +84,13 @@ class SandboxManagerInjectFilesTest < ActiveSupport::TestCase
     refute binds.any? { |b| b.end_with?(":/home/#{@user.name}/.claude") },
       "persisted paths should not be bound separately when full home is bound"
   end
+
+  test "volume_binds mounts a scoped home subdir as home and skips persisted dotdirs" do
+    @user.persisted_paths.find_or_create_by!(path: ".claude")
+    @sandbox.update!(mount_home: false, home_path: "projects/demo")
+
+    binds = @manager.send(:volume_binds, @user, @sandbox)
+    assert binds.any? { |b| b.end_with?("/home/projects/demo:/home/#{@user.name}") }
+    refute binds.any? { |b| b.end_with?(":/home/#{@user.name}/.claude") }
+  end
 end

--- a/test/services/sandbox_manager_test.rb
+++ b/test/services/sandbox_manager_test.rb
@@ -201,4 +201,17 @@ class SandboxManagerTest < ActiveSupport::TestCase
     assert ensure_called,
       "SandboxManager#start must call ensure_mount_dirs for data_path sandboxes too"
   end
+
+  test "start calls ensure_mount_dirs for sandboxes with home_path to reset bind-mount permissions" do
+    @sandbox.update!(home_path: "projects/demo", mount_home: false, status: "stopped", container_id: nil)
+
+    ensure_called = false
+    manager = Class.new(SandboxManager) {
+      define_method(:ensure_mount_dirs) { |_user, _sandbox| ensure_called = true }
+    }.new
+    manager.start(sandbox: @sandbox)
+
+    assert ensure_called,
+      "SandboxManager#start must call ensure_mount_dirs for home_path sandboxes too"
+  end
 end

--- a/test/system/sandbox_lifecycle_test.rb
+++ b/test/system/sandbox_lifecycle_test.rb
@@ -5,120 +5,49 @@ require "application_system_test_case"
 class SandboxLifecycleTest < ApplicationSystemTestCase
   setup do
     @user = users(:thies)
-    login_as(@user)
     DockerMock.reset!
   end
 
-  test "complete sandbox lifecycle: create, view, start, stop, destroy" do
-    # Navigate to dashboard
-    visit root_path
-    assert_text "Dashboard"
+  test "creating a sandbox from a saved project sets a project-specific hostname" do
+    login_as(@user)
 
-    # Create new sandbox
-    click_on "New Sandbox"
-    fill_in "Name", with: "test-lifecycle"
-    check "Persistent volume"
-    click_on "Create Sandbox"
+    click_on "Create Sandcastle"
+    assert_text "Create Sandcastle"
 
-    # Should see flash message
-    assert_text "Creating sandbox"
+    click_on "New Project"
+    assert_text "Create Project"
 
-    # Wait for provision job to complete
+    fill_in "Name", with: "alpha"
+    fill_in "Project Subdir", with: "projects/alpha"
+    click_on "Create Project"
+
+    assert_text "Project alpha created."
+    assert_text "Create Sandcastle"
+
+    fill_in "sandbox_name", with: "promptbox"
+    select "alpha (projects/alpha)", from: "sandbox_project_id"
+    click_on "Create Sandcastle"
+
+    assert_text "Creating sandcastle promptbox"
+
     perform_enqueued_jobs
 
-    # Should see sandbox in list
-    visit root_path
-    assert_text "test-lifecycle"
-    assert_text "running"
+    sandbox = @user.sandboxes.find_by!(name: "promptbox")
+    assert_equal "alpha", sandbox.project_name
+    assert_equal "promptbox-alpha", sandbox.hostname
 
-    # Stop sandbox
-    within "#sandbox_test-lifecycle" do
-      click_on "Stop"
-    end
-
-    # Wait for stop job
-    perform_enqueued_jobs
-
-    # Should see stopped status
-    visit root_path
-    within "#sandbox_test-lifecycle" do
-      assert_text "stopped"
-    end
-
-    # Start sandbox again
-    within "#sandbox_test-lifecycle" do
-      click_on "Start"
-    end
-
-    # Wait for start job
-    perform_enqueued_jobs
-
-    # Should see running status
-    visit root_path
-    within "#sandbox_test-lifecycle" do
-      assert_text "running"
-    end
-
-    # Destroy sandbox
-    within "#sandbox_test-lifecycle" do
-      accept_confirm do
-        click_on "Destroy"
-      end
-    end
-
-    # Wait for destroy job
-    perform_enqueued_jobs
-
-    # Should no longer see sandbox in list (destroyed sandboxes are hidden)
-    visit root_path
-    assert_no_text "test-lifecycle"
-  end
-
-  test "flash messages auto-dismiss" do
-    visit root_path
-
-    # Create sandbox to trigger flash
-    click_on "New Sandbox"
-    fill_in "Name", with: "flash-test"
-    click_on "Create Sandbox"
-
-    # Flash should appear
-    assert_selector "[data-controller='flash']"
-    assert_text "Creating sandbox"
-
-    # Wait for auto-dismiss (5 seconds)
-    using_wait_time(6) do
-      assert_no_selector "[data-controller='flash']"
-    end
-  end
-
-  test "stats load asynchronously" do
-    # Create a running sandbox first
-    sandbox = @user.sandboxes.create!(
-      name: "stats-test",
-      status: "pending",
-      image: "ghcr.io/thieso2/sandcastle-sandbox:latest"
-    )
-
-    perform_enqueued_jobs do
-      SandboxProvisionJob.perform_later(sandbox_id: sandbox.id)
-    end
-
-    visit root_path
-
-    # Stats frame should load
-    within "#sandbox_#{sandbox.name}" do
-      # Initially shows loading or stats
-      assert_selector "turbo-frame[src*='/sandboxes/#{sandbox.id}/stats']"
-    end
+    container = Docker::Container.get(sandbox.container_id)
+    assert_equal "promptbox-alpha", container.json.dig("Config", "Hostname")
+    assert_equal sandbox.full_name, container.json.dig("Config", "name")
   end
 
   private
 
   def login_as(user)
     visit new_session_path
-    fill_in "Email address", with: user.email_address
-    fill_in "Password", with: "Secret1*3*5*"
+    fill_in "email_address", with: user.email_address
+    fill_in "password", with: "password"
     click_on "Sign in"
+    assert_text "My Sandcastles"
   end
 end

--- a/vendor/sandcastle-cli/api/client.go
+++ b/vendor/sandcastle-cli/api/client.go
@@ -264,6 +264,28 @@ func (c *Client) CreateSandbox(req CreateSandboxRequest) (*Sandbox, error) {
 	return &s, err
 }
 
+func (c *Client) ListProjects() ([]Project, error) {
+	var projects []Project
+	err := c.do("GET", "/api/projects", nil, &projects)
+	return projects, err
+}
+
+func (c *Client) GetProject(id int) (*Project, error) {
+	var project Project
+	err := c.do("GET", fmt.Sprintf("/api/projects/%d", id), nil, &project)
+	return &project, err
+}
+
+func (c *Client) CreateProject(req CreateProjectRequest) (*Project, error) {
+	var project Project
+	err := c.do("POST", "/api/projects", map[string]any{"project": req}, &project)
+	return &project, err
+}
+
+func (c *Client) DestroyProject(id int) error {
+	return c.do("DELETE", fmt.Sprintf("/api/projects/%d", id), nil, nil)
+}
+
 func (c *Client) UpdateSandbox(id int, req UpdateSandboxRequest) (*Sandbox, error) {
 	var s Sandbox
 	err := c.do("PATCH", fmt.Sprintf("/api/sandboxes/%d", id), req, &s)

--- a/vendor/sandcastle-cli/api/types.go
+++ b/vendor/sandcastle-cli/api/types.go
@@ -3,27 +3,31 @@ package api
 import "time"
 
 type Sandbox struct {
-	ID               int       `json:"id"`
-	Name             string    `json:"name"`
-	FullName         string    `json:"full_name"`
-	Status           string    `json:"status"`
-	Image            string    `json:"image"`
-	SSHPort          int       `json:"ssh_port,omitempty"`
-	MountHome        bool      `json:"mount_home"`
-	DataPath         string    `json:"data_path,omitempty"`
-	Temporary        bool      `json:"temporary"`
-	Tailscale        bool           `json:"tailscale"`
-	TailscaleIP      string         `json:"tailscale_ip,omitempty"`
-	VNCEnabled       bool           `json:"vnc_enabled"`
-	VNCGeometry      string         `json:"vnc_geometry,omitempty"`
-	VNCDepth         int            `json:"vnc_depth,omitempty"`
-	DockerEnabled    bool           `json:"docker_enabled"`
-	SMBEnabled       bool           `json:"smb_enabled"`
-	Routes           []SandboxRoute `json:"routes"`
-	ConnectCommand   string         `json:"connect_command"`
-	ImageBuiltAt     *time.Time     `json:"image_built_at,omitempty"`
-	CreatedAt        time.Time      `json:"created_at"`
-	ArchivedAt       *time.Time     `json:"archived_at,omitempty"`
+	ID             int            `json:"id"`
+	Name           string         `json:"name"`
+	FullName       string         `json:"full_name"`
+	Hostname       string         `json:"hostname,omitempty"`
+	Status         string         `json:"status"`
+	Image          string         `json:"image"`
+	SSHPort        int            `json:"ssh_port,omitempty"`
+	ProjectName    string         `json:"project_name,omitempty"`
+	MountHome      bool           `json:"mount_home"`
+	HomePath       string         `json:"home_path,omitempty"`
+	DataPath       string         `json:"data_path,omitempty"`
+	ProjectPath    string         `json:"project_path,omitempty"`
+	Temporary      bool           `json:"temporary"`
+	Tailscale      bool           `json:"tailscale"`
+	TailscaleIP    string         `json:"tailscale_ip,omitempty"`
+	VNCEnabled     bool           `json:"vnc_enabled"`
+	VNCGeometry    string         `json:"vnc_geometry,omitempty"`
+	VNCDepth       int            `json:"vnc_depth,omitempty"`
+	DockerEnabled  bool           `json:"docker_enabled"`
+	SMBEnabled     bool           `json:"smb_enabled"`
+	Routes         []SandboxRoute `json:"routes"`
+	ConnectCommand string         `json:"connect_command"`
+	ImageBuiltAt   *time.Time     `json:"image_built_at,omitempty"`
+	CreatedAt      time.Time      `json:"created_at"`
+	ArchivedAt     *time.Time     `json:"archived_at,omitempty"`
 }
 
 type SandboxRoute struct {
@@ -54,14 +58,14 @@ type User struct {
 }
 
 type Token struct {
-	ID         int        `json:"id"`
-	Name       string     `json:"name"`
-	Prefix     string     `json:"prefix"`
-	MaskedToken string    `json:"masked_token"`
-	RawToken   string     `json:"raw_token,omitempty"`
-	LastUsedAt *time.Time `json:"last_used_at"`
-	ExpiresAt  *time.Time `json:"expires_at"`
-	CreatedAt  time.Time  `json:"created_at"`
+	ID          int        `json:"id"`
+	Name        string     `json:"name"`
+	Prefix      string     `json:"prefix"`
+	MaskedToken string     `json:"masked_token"`
+	RawToken    string     `json:"raw_token,omitempty"`
+	LastUsedAt  *time.Time `json:"last_used_at"`
+	ExpiresAt   *time.Time `json:"expires_at"`
+	CreatedAt   time.Time  `json:"created_at"`
 }
 
 type SystemStatus struct {
@@ -123,29 +127,29 @@ type ServerUserCounts struct {
 }
 
 type Snapshot struct {
-	Name          string    `json:"name"`
-	Label         string    `json:"label,omitempty"`
-	SourceSandbox string    `json:"source_sandbox,omitempty"`
-	Layers        []string  `json:"layers,omitempty"`
+	Name          string   `json:"name"`
+	Label         string   `json:"label,omitempty"`
+	SourceSandbox string   `json:"source_sandbox,omitempty"`
+	Layers        []string `json:"layers,omitempty"`
 	// Legacy field for backward compat
-	Image         string    `json:"image,omitempty"`
-	DockerImage   string    `json:"docker_image,omitempty"`
-	DockerSize    int64     `json:"docker_size,omitempty"`
-	HomeSize      int64     `json:"home_size,omitempty"`
-	DataSize      int64     `json:"data_size,omitempty"`
-	TotalSize     int64     `json:"total_size,omitempty"`
+	Image       string `json:"image,omitempty"`
+	DockerImage string `json:"docker_image,omitempty"`
+	DockerSize  int64  `json:"docker_size,omitempty"`
+	HomeSize    int64  `json:"home_size,omitempty"`
+	DataSize    int64  `json:"data_size,omitempty"`
+	TotalSize   int64  `json:"total_size,omitempty"`
 	// Legacy size field
-	Size          int64     `json:"size,omitempty"`
+	Size int64 `json:"size,omitempty"`
 	// Legacy sandbox field
-	Sandbox       string    `json:"sandbox,omitempty"`
-	CreatedAt     time.Time `json:"created_at"`
+	Sandbox   string    `json:"sandbox,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type SnapshotRequest struct {
-	Name      string   `json:"name,omitempty"`
-	Label     string   `json:"label,omitempty"`
-	Layers    []string `json:"layers,omitempty"`
-	DataSubdir string  `json:"data_subdir,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	Label      string   `json:"label,omitempty"`
+	Layers     []string `json:"layers,omitempty"`
+	DataSubdir string   `json:"data_subdir,omitempty"`
 }
 
 type CreateSnapshotRequest struct {
@@ -184,8 +188,12 @@ type CreateSandboxRequest struct {
 	Snapshot      string   `json:"snapshot,omitempty"`
 	FromSnapshot  string   `json:"from_snapshot,omitempty"`
 	RestoreLayers []string `json:"restore_layers,omitempty"`
+	ProjectID     int      `json:"project_id,omitempty"`
+	ProjectName   string   `json:"project_name,omitempty"`
+	ProjectPath   string   `json:"project_path,omitempty"`
 	Tailscale     bool     `json:"tailscale,omitempty"`
 	MountHome     bool     `json:"mount_home,omitempty"`
+	HomePath      string   `json:"home_path,omitempty"`
 	DataPath      string   `json:"data_path,omitempty"`
 	Temporary     bool     `json:"temporary,omitempty"`
 	VNCEnabled    bool     `json:"vnc_enabled"`
@@ -198,6 +206,34 @@ type CreateSandboxRequest struct {
 type UpdateSandboxRequest struct {
 	Temporary *bool   `json:"temporary,omitempty"`
 	Name      *string `json:"name,omitempty"`
+}
+
+type Project struct {
+	ID            int       `json:"id"`
+	Name          string    `json:"name"`
+	Path          string    `json:"path"`
+	Image         string    `json:"image"`
+	Tailscale     bool      `json:"tailscale"`
+	VNCEnabled    bool      `json:"vnc_enabled"`
+	VNCGeometry   string    `json:"vnc_geometry,omitempty"`
+	VNCDepth      int       `json:"vnc_depth,omitempty"`
+	DockerEnabled bool      `json:"docker_enabled"`
+	SMBEnabled    bool      `json:"smb_enabled"`
+	SSHStartTmux  bool      `json:"ssh_start_tmux"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+type CreateProjectRequest struct {
+	Name          string `json:"name"`
+	Path          string `json:"path"`
+	Image         string `json:"image,omitempty"`
+	Tailscale     bool   `json:"tailscale,omitempty"`
+	VNCEnabled    bool   `json:"vnc_enabled"`
+	VNCGeometry   string `json:"vnc_geometry,omitempty"`
+	VNCDepth      int    `json:"vnc_depth,omitempty"`
+	DockerEnabled bool   `json:"docker_enabled"`
+	SMBEnabled    bool   `json:"smb_enabled,omitempty"`
+	SSHStartTmux  bool   `json:"ssh_start_tmux"`
 }
 
 type CreateTokenRequest struct {
@@ -232,15 +268,15 @@ type TailscaleLoginStatus struct {
 }
 
 type TailscaleStatus struct {
-	Running            bool                `json:"running"`
-	ContainerID        string              `json:"container_id"`
-	Network            string              `json:"network"`
-	ConnectedSandboxes int                 `json:"connected_sandboxes"`
-	TailscaleIP        string              `json:"tailscale_ip"`
-	Hostname           string              `json:"hostname"`
-	Tailnet            string              `json:"tailnet"`
-	Online             bool                `json:"online"`
-	Sandboxes          []TailscaleSandbox  `json:"sandboxes"`
+	Running            bool               `json:"running"`
+	ContainerID        string             `json:"container_id"`
+	Network            string             `json:"network"`
+	ConnectedSandboxes int                `json:"connected_sandboxes"`
+	TailscaleIP        string             `json:"tailscale_ip"`
+	Hostname           string             `json:"hostname"`
+	Tailnet            string             `json:"tailnet"`
+	Online             bool               `json:"online"`
+	Sandboxes          []TailscaleSandbox `json:"sandboxes"`
 }
 
 type TailscaleSandbox struct {

--- a/vendor/sandcastle-cli/cmd/project.go
+++ b/vendor/sandcastle-cli/cmd/project.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/sandcastle/cli/api"
+	"github.com/spf13/cobra"
+)
+
+var (
+	projectPath         string
+	projectImage        string
+	projectTailscale    bool
+	projectNoVNC        bool
+	projectVNCGeometry  string
+	projectVNCDepth     int
+	projectNoDocker     bool
+	projectSMB          bool
+	projectSSHStartTmux bool
+)
+
+func init() {
+	rootCmd.AddCommand(projectCmd)
+	projectCmd.AddCommand(projectListCmd)
+	projectCmd.AddCommand(projectCreateCmd)
+	projectCmd.AddCommand(projectDeleteCmd)
+
+	projectCreateCmd.Flags().StringVar(&projectPath, "path", "", "Project subdir mounted as both $HOME and /persisted")
+	projectCreateCmd.Flags().StringVar(&projectImage, "image", "ghcr.io/thieso2/sandcastle-sandbox:latest", "Default container image")
+	projectCreateCmd.Flags().BoolVar(&projectTailscale, "tailscale", false, "Enable Tailscale by default")
+	projectCreateCmd.Flags().BoolVar(&projectNoVNC, "no-vnc", false, "Disable VNC by default")
+	projectCreateCmd.Flags().StringVar(&projectVNCGeometry, "vnc-geometry", "", "Default VNC screen resolution")
+	projectCreateCmd.Flags().IntVar(&projectVNCDepth, "vnc-depth", 0, "Default VNC color depth")
+	projectCreateCmd.Flags().BoolVar(&projectNoDocker, "no-docker", false, "Disable Docker by default")
+	projectCreateCmd.Flags().BoolVar(&projectSMB, "smb", false, "Enable SMB by default")
+	projectCreateCmd.Flags().BoolVar(&projectSSHStartTmux, "ssh-start-tmux", true, "Start tmux on SSH login by default")
+}
+
+var projectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage reusable project presets",
+}
+
+var projectListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List saved projects",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+
+		projects, err := client.ListProjects()
+		if err != nil {
+			return err
+		}
+		sort.Slice(projects, func(i, j int) bool { return projects[i].Name < projects[j].Name })
+
+		if len(projects) == 0 {
+			fmt.Println("No projects saved.")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tPATH\tIMAGE\tSERVICES")
+		for _, p := range projects {
+			services := []string{}
+			if p.DockerEnabled {
+				services = append(services, "docker")
+			}
+			if p.VNCEnabled {
+				services = append(services, "vnc")
+			}
+			if p.Tailscale {
+				services = append(services, "tailscale")
+			}
+			if p.SMBEnabled {
+				services = append(services, "smb")
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, p.Path, p.Image, joinCSV(services))
+		}
+		return w.Flush()
+	},
+}
+
+var projectCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a reusable project preset",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if projectPath == "" {
+			return fmt.Errorf("--path is required")
+		}
+
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+
+		project, err := client.CreateProject(api.CreateProjectRequest{
+			Name:          args[0],
+			Path:          projectPath,
+			Image:         projectImage,
+			Tailscale:     projectTailscale,
+			VNCEnabled:    !projectNoVNC,
+			VNCGeometry:   projectVNCGeometry,
+			VNCDepth:      projectVNCDepth,
+			DockerEnabled: !projectNoDocker,
+			SMBEnabled:    projectSMB,
+			SSHStartTmux:  projectSSHStartTmux,
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Project %q created (%s).\n", project.Name, project.Path)
+		return nil
+	},
+}
+
+var projectDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a project preset",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+		return client.DestroyProject(id)
+	},
+}
+
+func joinCSV(items []string) string {
+	if len(items) == 0 {
+		return "-"
+	}
+	out := items[0]
+	for i := 1; i < len(items); i++ {
+		out += "," + items[i]
+	}
+	return out
+}
+
+func parseID(s string) (int, error) {
+	var id int
+	_, err := fmt.Sscanf(s, "%d", &id)
+	if err != nil {
+		return 0, fmt.Errorf("invalid id %q", s)
+	}
+	return id, nil
+}

--- a/vendor/sandcastle-cli/cmd/sandbox.go
+++ b/vendor/sandcastle-cli/cmd/sandbox.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -24,6 +24,9 @@ var (
 	sandboxNoConnect     bool
 	sandboxRemove        bool
 	sandboxHome          bool
+	sandboxHomeSubdir    string
+	sandboxProject       string
+	sandboxProjectSubdir string
 	sandboxData          string
 	sandboxNoVNC         bool
 	sandboxVNCGeometry   string
@@ -56,6 +59,9 @@ func init() {
 	createCmd.Flags().BoolVarP(&sandboxNoConnect, "no-connect", "n", false, "Don't connect after creation")
 	createCmd.Flags().BoolVar(&sandboxRemove, "rm", false, "Delete sandbox on exit (env: SANDCASTLE_RM)")
 	createCmd.Flags().BoolVar(&sandboxHome, "home", false, "Mount persistent home directory (env: SANDCASTLE_HOME)")
+	createCmd.Flags().StringVar(&sandboxHomeSubdir, "home-subdir", "", "Mount this subdir of persistent home as $HOME")
+	createCmd.Flags().StringVar(&sandboxProject, "project", "", "Create the sandbox from a saved project preset")
+	createCmd.Flags().StringVar(&sandboxProjectSubdir, "project-subdir", "", "Mount this subdir as both $HOME and /persisted")
 	createCmd.Flags().StringVar(&sandboxData, "data", "", "Mount user data directory (or subpath) to /persisted (env: SANDCASTLE_DATA)")
 	createCmd.Flags().Lookup("data").NoOptDefVal = "."
 	createCmd.Flags().BoolVar(&sandboxNoVNC, "no-vnc", false, "Disable VNC display server")
@@ -143,13 +149,21 @@ Flags explicitly passed on the command line take precedence over environment var
 			}
 		}
 
-		sandbox, err := client.CreateSandbox(api.CreateSandboxRequest{
+		if sandboxHome && sandboxHomeSubdir != "" {
+			return fmt.Errorf("--home and --home-subdir are mutually exclusive")
+		}
+		if sandboxProject != "" && sandboxProjectSubdir != "" {
+			return fmt.Errorf("--project and --project-subdir cannot be combined")
+		}
+
+		req := api.CreateSandboxRequest{
 			Name:          name,
 			Image:         sandboxImage,
 			FromSnapshot:  fromSnap,
 			RestoreLayers: restoreLayers,
 			Tailscale:     sandboxTailscale,
 			MountHome:     sandboxHome,
+			HomePath:      sandboxHomeSubdir,
 			DataPath:      sandboxData,
 			Temporary:     sandboxRemove,
 			VNCEnabled:    !sandboxNoVNC,
@@ -157,7 +171,17 @@ Flags explicitly passed on the command line take precedence over environment var
 			VNCDepth:      sandboxVNCDepth,
 			DockerEnabled: !sandboxNoDocker,
 			SMBEnabled:    sandboxSMB,
-		})
+		}
+		if sandboxProject != "" {
+			req.ProjectName = sandboxProject
+		}
+		if sandboxProjectSubdir != "" {
+			req.ProjectPath = sandboxProjectSubdir
+			req.HomePath = ""
+			req.MountHome = false
+			req.DataPath = ""
+		}
+		sandbox, err := client.CreateSandbox(req)
 		if err != nil {
 			return err
 		}
@@ -169,9 +193,18 @@ Flags explicitly passed on the command line take precedence over environment var
 		}
 
 		// Print active options (use local flags — they reflect what was actually requested)
-		if sandboxHome || sandboxData != "" || sandbox.Tailscale || sandboxRemove || fromSnap != "" || sandboxNoVNC || sandboxVNCGeometry != "" || sandboxVNCDepth != 0 || sandboxNoDocker || sandboxSMB {
+		if sandboxHome || sandboxHomeSubdir != "" || sandboxProject != "" || sandboxProjectSubdir != "" || sandboxData != "" || sandbox.Tailscale || sandboxRemove || fromSnap != "" || sandboxNoVNC || sandboxVNCGeometry != "" || sandboxVNCDepth != 0 || sandboxNoDocker || sandboxSMB {
 			if sandboxHome {
 				fmt.Println("  Home:      mounted (~/ persisted)")
+			}
+			if sandboxHomeSubdir != "" {
+				fmt.Printf("  Home:      mounted (%s → $HOME)\n", sandboxHomeSubdir)
+			}
+			if sandboxProject != "" {
+				fmt.Printf("  Project:   %s\n", sandboxProject)
+			}
+			if sandboxProjectSubdir != "" {
+				fmt.Printf("  Project:   %s (scoped home + persisted)\n", sandboxProjectSubdir)
 			}
 			if sandboxData != "" {
 				label := sandboxData
@@ -339,7 +372,7 @@ var listCmd = &cobra.Command{
 			if s.TailscaleIP != "" {
 				tsIP = s.TailscaleIP
 			}
-			created  := s.CreatedAt.Local().Format("2006-01-02 15:04")
+			created := s.CreatedAt.Local().Format("2006-01-02 15:04")
 			imageAge := formatImageAge(s.ImageBuiltAt)
 			if hasRoute {
 				route := ""
@@ -394,7 +427,7 @@ var deleteCmd = &cobra.Command{
 	Use:     "delete <name>",
 	Aliases: []string{"rm", "d"},
 	Short:   "Delete a sandbox",
-	Args:  cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := api.NewClient()
 		if err != nil {
@@ -431,7 +464,7 @@ var startCmd = &cobra.Command{
 	Use:     "start <name>",
 	Aliases: []string{"up"},
 	Short:   "Start a stopped sandbox",
-	Args:  cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := api.NewClient()
 		if err != nil {
@@ -458,7 +491,7 @@ var stopCmd = &cobra.Command{
 	Use:     "stop <name>",
 	Aliases: []string{"dn"},
 	Short:   "Stop a running sandbox",
-	Args:  cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := api.NewClient()
 		if err != nil {

--- a/vendor/sandcastle-cli/cmd/tui.go
+++ b/vendor/sandcastle-cli/cmd/tui.go
@@ -42,7 +42,6 @@ var (
 	headerStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(lipgloss.Color("75"))
-
 )
 
 // ---------- views ----------
@@ -53,6 +52,7 @@ const (
 	viewSandboxes tuiView = iota
 	viewRoutes
 	viewCreateSandbox
+	viewCreateProject
 	viewAddRoute
 	viewConfirmDelete
 	viewServers
@@ -138,23 +138,27 @@ type tuiModel struct {
 	routeCursor  int
 
 	// create sandbox form
-	createFields   []formField
-	createCursor   int
-	snapshots      []api.Snapshot // cached for snapshot name completion
+	createFields []formField
+	createCursor int
+	snapshots    []api.Snapshot // cached for snapshot name completion
+
+	// create project form
+	projectFields []formField
+	projectCursor int
 
 	// add route
-	routeInputs    [2]textinput.Model // domain, port
-	routeFocusIdx  int
+	routeInputs   [2]textinput.Model // domain, port
+	routeFocusIdx int
 
 	// confirm delete
 	deleteTarget string
 	deleteID     int
 
 	// server management
-	servers       []serverEntry
-	serverCursor  int
-	addServerInputs [2]textinput.Model // URL, alias
-	addServerFocus  int
+	servers           []serverEntry
+	serverCursor      int
+	addServerInputs   [2]textinput.Model // URL, alias
+	addServerFocus    int
 	addServerInsecure bool
 
 	// device auth login
@@ -176,9 +180,9 @@ type tuiModel struct {
 }
 
 type serverEntry struct {
-	alias   string
-	url     string
-	active  bool
+	alias    string
+	url      string
+	active   bool
 	hasToken bool
 }
 
@@ -195,10 +199,13 @@ const (
 	cfName = iota
 	cfImage
 	cfSnapshot
+	cfProject
 	cfDocker
 	cfVNC
 	cfTailscale
 	cfHome
+	cfHomeSubdir
+	cfProjectSubdir
 	cfData
 	cfSMB
 	cfTemporary
@@ -210,13 +217,40 @@ func buildCreateFields() []formField {
 		{label: "Name", kind: fieldText, input: makeTextInput("leave empty for auto-generated name", 45)},
 		{label: "Image", kind: fieldText, input: makeTextInput("ghcr.io/thieso2/sandcastle-sandbox:latest", 55)},
 		{label: "Snapshot", kind: fieldText, input: makeTextInput("snapshot name to restore from", 45)},
+		{label: "Project", kind: fieldText, input: makeTextInput("saved project preset name", 45)},
 		{label: "Docker", kind: fieldBool, boolVal: true, defBool: true},
 		{label: "VNC", kind: fieldBool, boolVal: true, defBool: true},
 		{label: "Tailscale", kind: fieldBool, boolVal: false, defBool: false},
 		{label: "Home", kind: fieldBool, boolVal: false, defBool: false},
+		{label: "Home subdir", kind: fieldText, input: makeTextInput("subdir mounted as $HOME", 45)},
+		{label: "Project subdir", kind: fieldText, input: makeTextInput("subdir mounted as $HOME and /persisted", 45)},
 		{label: "Data path", kind: fieldText, input: makeTextInput("subpath or . for root (empty = none)", 45)},
 		{label: "SMB", kind: fieldBool, boolVal: false, defBool: false},
 		{label: "Temporary", kind: fieldBool, boolVal: false, defBool: false},
+	}
+}
+
+const (
+	pfName = iota
+	pfPath
+	pfImage
+	pfDocker
+	pfVNC
+	pfTailscale
+	pfSMB
+	pfSSHStartTmux
+)
+
+func buildProjectFields() []formField {
+	return []formField{
+		{label: "Name", kind: fieldText, input: makeTextInput("project preset name", 45)},
+		{label: "Path", kind: fieldText, input: makeTextInput("subdir mounted as $HOME and /persisted", 55)},
+		{label: "Image", kind: fieldText, input: makeTextInput("ghcr.io/thieso2/sandcastle-sandbox:latest", 55)},
+		{label: "Docker", kind: fieldBool, boolVal: true, defBool: true},
+		{label: "VNC", kind: fieldBool, boolVal: true, defBool: true},
+		{label: "Tailscale", kind: fieldBool, boolVal: false, defBool: false},
+		{label: "SMB", kind: fieldBool, boolVal: false, defBool: false},
+		{label: "SSH tmux", kind: fieldBool, boolVal: true, defBool: true},
 	}
 }
 
@@ -292,11 +326,12 @@ func newTUI(client *api.Client) tuiModel {
 	portInput.CharLimit = 5
 
 	return tuiModel{
-		client:       client,
-		spinner:      s,
-		loading:      true,
-		createFields: buildCreateFields(),
-		routeInputs:  [2]textinput.Model{domainInput, portInput},
+		client:        client,
+		spinner:       s,
+		loading:       true,
+		createFields:  buildCreateFields(),
+		projectFields: buildProjectFields(),
+		routeInputs:   [2]textinput.Model{domainInput, portInput},
 	}
 }
 
@@ -474,6 +509,8 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateRoutes(msg)
 	case viewCreateSandbox:
 		return m.updateCreate(msg)
+	case viewCreateProject:
+		return m.updateCreateProject(msg)
 	case viewAddRoute:
 		return m.updateAddRoute(msg)
 	case viewConfirmDelete:
@@ -517,6 +554,12 @@ func (m tuiModel) updateSandboxes(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, loadSnapshots(m.client))
 			}
 			return m, tea.Batch(cmds...)
+		case key.Matches(msg, key.NewBinding(key.WithKeys("g"))):
+			m.view = viewCreateProject
+			m.projectFields = buildProjectFields()
+			m.projectCursor = 0
+			m.projectFields[0].input.Focus()
+			return m, m.projectFields[0].input.Cursor.BlinkCmd()
 		case key.Matches(msg, key.NewBinding(key.WithKeys("r"))):
 			if len(m.sandboxes) > 0 {
 				m.loading = true
@@ -744,16 +787,28 @@ func (m tuiModel) submitCreateForm() (tea.Model, tea.Cmd) {
 		image = "ghcr.io/thieso2/sandcastle-sandbox:latest"
 	}
 	snapshot := strings.TrimSpace(m.createFields[cfSnapshot].input.Value())
+	project := strings.TrimSpace(m.createFields[cfProject].input.Value())
+	homePath := strings.TrimSpace(m.createFields[cfHomeSubdir].input.Value())
+	projectPath := strings.TrimSpace(m.createFields[cfProjectSubdir].input.Value())
 	dataPath := strings.TrimSpace(m.createFields[cfData].input.Value())
+
+	if project != "" && projectPath != "" {
+		m.feedback = "project preset and project subdir cannot be combined"
+		m.feedErr = true
+		return m, nil
+	}
 
 	req := api.CreateSandboxRequest{
 		Name:          name,
 		Image:         image,
 		FromSnapshot:  snapshot,
+		ProjectName:   project,
 		DockerEnabled: m.createFields[cfDocker].boolVal,
 		VNCEnabled:    m.createFields[cfVNC].boolVal,
 		Tailscale:     m.createFields[cfTailscale].boolVal,
 		MountHome:     m.createFields[cfHome].boolVal,
+		HomePath:      homePath,
+		ProjectPath:   projectPath,
 		DataPath:      dataPath,
 		SMBEnabled:    m.createFields[cfSMB].boolVal,
 		Temporary:     m.createFields[cfTemporary].boolVal,
@@ -767,6 +822,106 @@ func (m tuiModel) submitCreateForm() (tea.Model, tea.Cmd) {
 			return "", err
 		}
 		return fmt.Sprintf("%q created", sb.Name), nil
+	}))
+}
+
+func (m tuiModel) projectFocusField(idx int) (tuiModel, tea.Cmd) {
+	for i := range m.projectFields {
+		if m.projectFields[i].kind == fieldText {
+			m.projectFields[i].input.Blur()
+		}
+	}
+	m.projectCursor = idx
+	if m.projectFields[idx].kind == fieldText {
+		m.projectFields[idx].input.Focus()
+		return m, m.projectFields[idx].input.Cursor.BlinkCmd()
+	}
+	return m, nil
+}
+
+func (m tuiModel) updateCreateProject(msg tea.Msg) (tea.Model, tea.Cmd) {
+	f := &m.projectFields[m.projectCursor]
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEsc:
+			m.view = viewSandboxes
+			m.feedback = ""
+			return m, nil
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		case tea.KeyUp:
+			if m.projectCursor > 0 {
+				return m.projectFocusField(m.projectCursor - 1)
+			}
+			return m, nil
+		case tea.KeyDown, tea.KeyTab:
+			if m.projectCursor < len(m.projectFields)-1 {
+				return m.projectFocusField(m.projectCursor + 1)
+			}
+			return m, nil
+		case tea.KeyShiftTab:
+			if m.projectCursor > 0 {
+				return m.projectFocusField(m.projectCursor - 1)
+			}
+			return m, nil
+		case tea.KeyEnter:
+			if f.kind == fieldBool {
+				f.boolVal = !f.boolVal
+				return m, nil
+			}
+			return m.submitCreateProjectForm()
+		case tea.KeyCtrlS:
+			return m.submitCreateProjectForm()
+		}
+
+		if f.kind == fieldBool && msg.String() == " " {
+			f.boolVal = !f.boolVal
+			return m, nil
+		}
+	}
+
+	if f.kind == fieldText {
+		var cmd tea.Cmd
+		f.input, cmd = f.input.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m tuiModel) submitCreateProjectForm() (tea.Model, tea.Cmd) {
+	name := strings.TrimSpace(m.projectFields[pfName].input.Value())
+	path := strings.TrimSpace(m.projectFields[pfPath].input.Value())
+	image := strings.TrimSpace(m.projectFields[pfImage].input.Value())
+	if image == "" {
+		image = "ghcr.io/thieso2/sandcastle-sandbox:latest"
+	}
+	if name == "" || path == "" {
+		m.feedback = "name and path are required"
+		m.feedErr = true
+		return m, nil
+	}
+
+	req := api.CreateProjectRequest{
+		Name:          name,
+		Path:          path,
+		Image:         image,
+		DockerEnabled: m.projectFields[pfDocker].boolVal,
+		VNCEnabled:    m.projectFields[pfVNC].boolVal,
+		Tailscale:     m.projectFields[pfTailscale].boolVal,
+		SMBEnabled:    m.projectFields[pfSMB].boolVal,
+		SSHStartTmux:  m.projectFields[pfSSHStartTmux].boolVal,
+	}
+
+	m.view = viewSandboxes
+	m.loading = true
+	return m, tea.Batch(m.spinner.Tick, doAction(func() (string, error) {
+		project, err := m.client.CreateProject(req)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("project %q created", project.Name), nil
 	}))
 }
 
@@ -871,6 +1026,8 @@ func (m tuiModel) View() string {
 		m.viewRoutes(&b)
 	case viewCreateSandbox:
 		m.viewCreate(&b)
+	case viewCreateProject:
+		m.viewCreateProject(&b)
 	case viewAddRoute:
 		m.viewAddRoute(&b)
 	case viewConfirmDelete:
@@ -961,7 +1118,7 @@ func (m tuiModel) viewSandboxes(b *strings.Builder) {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("  enter connect  c create  s start  x stop  d destroy  r routes  S servers  P prefs  R refresh  q quit"))
+	b.WriteString(helpStyle.Render("  enter connect  c create sandbox  g create project  s start  x stop  d destroy  r routes  S servers  P prefs  R refresh  q quit"))
 	b.WriteString("\n")
 }
 
@@ -1050,6 +1207,40 @@ func (m tuiModel) viewCreate(b *strings.Builder) {
 					b.WriteString("  " + helpStyle.Render(hint))
 				}
 			}
+		case fieldBool:
+			check := checkOff
+			if f.boolVal {
+				check = checkOn
+			}
+			b.WriteString(fmt.Sprintf("%s%s %s", cursor, label, check))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(helpStyle.Render("  arrows/tab navigate  space toggle  ctrl+s create  esc cancel"))
+	b.WriteString("\n")
+}
+
+func (m tuiModel) viewCreateProject(b *strings.Builder) {
+	b.WriteString(headerStyle.Render("  Create Project") + "\n\n")
+	b.WriteString(helpStyle.Render("  Save a reusable preset with a scoped $HOME and /persisted path.") + "\n\n")
+
+	for i, f := range m.projectFields {
+		active := i == m.projectCursor
+		label := formLabelStyle.Render(f.label)
+		if active {
+			label = formLabelActiveStyle.Render(f.label)
+		}
+
+		cursor := "  "
+		if active {
+			cursor = "> "
+		}
+
+		switch f.kind {
+		case fieldText:
+			b.WriteString(fmt.Sprintf("%s%s %s", cursor, label, f.input.View()))
 		case fieldBool:
 			check := checkOff
 			if f.boolVal {


### PR DESCRIPTION
## Summary
- Adds a per-user **Project** model: a named bundle of sandbox defaults (image, VNC settings, Tailscale, SMB, SSH tmux, docker) with `ProjectPolicy`, web + API controllers, and a `projects/new` view.
- Sandboxes gain `project_name` and `home_path` columns. `Sandbox#hostname` composes `<name>-<project_name>` when a project is set; new validators normalize/guard `data_path` and `home_path`. `BtrfsHelper` learns to create per-project subvolumes.
- CLI/TUI gain a `project` subcommand (`vendor/sandcastle-cli/cmd/project.go`) and project-aware UX in sandbox views and the dashboard partial.
- Infra: lower in-container default UID/GID from 220568 → 22051 so user-namespaced runtimes (Sysbox) don't reject chown with EINVAL; route Rails test logs to STDOUT so containerized test runs don't depend on log-file ownership.

## Test plan
- [ ] `bin/rails db:migrate` runs the three new migrations cleanly
- [ ] `bin/rails test test/models/project_test.rb test/models/sandbox_test.rb`
- [ ] `bin/rails test test/services/sandbox_manager_test.rb test/services/sandbox_manager_inject_files_test.rb`
- [ ] `bin/rails test test/system/sandbox_lifecycle_test.rb`
- [ ] Manual: create a project via web UI, then create a sandbox using that project — verify hostname `<name>-<project_name>` and per-project subvolume layout
- [ ] Manual: `sandcastle project ...` CLI commands round-trip via the API
- [ ] `mise run deploy:dev` brings the stack up with the new UID defaults (no EINVAL on chown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Project presets: Create and reuse sandbox configurations with saved settings (image, path, Tailscale, VNC, Docker, SMB, SSH)
  * Home subdirectory support: Persist individual home directories within sandboxes
  * CLI and TUI project management: Create, list, and delete project presets from the command line

* **Improvements**
  * Sandboxes now inherit configuration from saved projects
  * Enhanced path validation and normalization for projects and home directories
  * Updated default container UID/GID values for improved Docker compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->