### PR TITLE
feat(ui): show <project>:<sandbox> as the sandbox display name

### DIFF
--- a/app/models/sandbox.rb
+++ b/app/models/sandbox.rb
@@ -43,6 +43,11 @@ class Sandbox < ApplicationRecord
     "#{name}-#{project_name}"
   end
 
+  def display_name
+    return name if project_name.blank?
+    "#{project_name}:#{name}"
+  end
+
   def connect_command
     "sandcastle connect #{name}"
   end

--- a/app/views/dashboard/_archived_sandbox.html.erb
+++ b/app/views/dashboard/_archived_sandbox.html.erb
@@ -3,7 +3,7 @@
 
   <div class="flex items-center gap-2 flex-wrap">
     <span class="inline-block w-2.5 h-2.5 rounded-full bg-gray-400"></span>
-    <span class="font-mono font-medium text-gray-600"><%= sandbox.name %></span>
+    <span class="font-mono font-medium text-gray-600"><% if sandbox.project_name.present? %><span class="text-gray-400"><%= sandbox.project_name %>:</span><% end %><%= sandbox.name %></span>
     <span class="text-xs text-gray-500 bg-gray-200 px-2 py-0.5 rounded">archived</span>
     <% if sandbox.mount_home? %>
       <span class="text-xs font-medium text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded">home</span>

--- a/app/views/dashboard/_sandbox.html.erb
+++ b/app/views/dashboard/_sandbox.html.erb
@@ -26,7 +26,7 @@
             end %>">
       </span>
 
-      <%= link_to sandbox.name, sandbox_path(sandbox), class: "font-mono font-medium text-gray-900 hover:text-blue-600 transition-colors" %>
+      <%= link_to sandbox_path(sandbox), class: "font-mono font-medium text-gray-900 hover:text-blue-600 transition-colors" do %><% if sandbox.project_name.present? %><span class="text-gray-400"><%= sandbox.project_name %>:</span><% end %><%= sandbox.name %><% end %>
 
       <%# Job status badge %>
       <% if sandbox.job_in_progress? %>
@@ -258,7 +258,7 @@
   <div id="snap-modal-<%= sandbox.id %>" class="hidden fixed inset-0 bg-black/40 flex items-center justify-center z-50" onclick="if(event.target===this)this.classList.add('hidden')">
     <div class="bg-white rounded-lg shadow-xl w-full max-w-sm mx-4">
       <div class="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
-        <h3 class="text-base font-semibold text-gray-900">Snapshot — <%= sandbox.name %></h3>
+        <h3 class="text-base font-semibold text-gray-900">Snapshot — <%= sandbox.display_name %></h3>
         <button onclick="document.getElementById('snap-modal-<%= sandbox.id %>').classList.add('hidden')" class="text-gray-400 hover:text-gray-600 text-lg leading-none">✕</button>
       </div>
       <%= form_with url: snapshot_sandbox_path(sandbox), method: :post, class: "px-5 py-4 space-y-3" do |f| %>

--- a/app/views/sandboxes/discover_files.html.erb
+++ b/app/views/sandboxes/discover_files.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-5xl mx-auto px-4 py-8">
   <div class="mb-6">
     <%= link_to sandbox_path(@sandbox), class: "text-sm text-blue-600 hover:text-blue-700" do %>
-      &larr; Back to <%= @sandbox.name %>
+      &larr; Back to <%= @sandbox.display_name %>
     <% end %>
   </div>
 

--- a/app/views/sandboxes/logs.html.erb
+++ b/app/views/sandboxes/logs.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:title) { "Logs — #{@sandbox.name} — Sandcastle" } %>
+<% content_for(:title) { "Logs — #{@sandbox.display_name} — Sandcastle" } %>
 
 <div class="max-w-5xl mx-auto px-4 py-8 space-y-4">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-3">
-      <h1 class="text-2xl font-bold text-gray-900 font-mono"><%= @sandbox.name %></h1>
+      <h1 class="text-2xl font-bold text-gray-900 font-mono"><% if @sandbox.project_name.present? %><span class="text-gray-400"><%= @sandbox.project_name %>:</span><% end %><%= @sandbox.name %></h1>
       <span class="text-sm text-gray-500">logs</span>
     </div>
     <div class="flex items-center gap-3">

--- a/app/views/sandboxes/show.html.erb
+++ b/app/views/sandboxes/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title) { "#{@sandbox.name} — Sandcastle" } %>
+<% content_for(:title) { "#{@sandbox.display_name} — Sandcastle" } %>
 
 <div class="max-w-3xl mx-auto px-4 py-6 sm:py-8 space-y-4 sm:space-y-6">
   <%# Header %>
@@ -7,7 +7,7 @@
       <div class="flex items-center gap-2 sm:gap-3 flex-wrap" data-controller="inline-edit">
         <span class="inline-block w-3 h-3 rounded-full shrink-0 <%= @sandbox.status == 'running' ? 'bg-green-500' : @sandbox.status == 'stopped' ? 'bg-yellow-500' : 'bg-gray-400' %>"></span>
         <h1 class="text-xl sm:text-2xl font-bold text-gray-900 font-mono break-all" data-inline-edit-target="display">
-          <%= @sandbox.name %>
+          <% if @sandbox.project_name.present? %><span class="text-gray-400"><%= @sandbox.project_name %>:</span><% end %><%= @sandbox.name %>
           <button data-action="click->inline-edit#edit" class="ml-1 text-gray-400 hover:text-gray-600 align-middle" title="Rename">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 inline">
               <path d="M13.488 2.513a1.75 1.75 0 0 0-2.475 0L3.22 10.303a.75.75 0 0 0-.178.311l-.93 3.255a.75.75 0 0 0 .926.926l3.255-.93a.75.75 0 0 0 .311-.178l7.79-7.79a1.75 1.75 0 0 0 0-2.475l-.906-.906ZM11.72 3.22a.25.25 0 0 1 .354 0l.905.906a.25.25 0 0 1 0 .354l-7.79 7.79-1.596.456.455-1.597 7.672-7.91Z" />
@@ -99,7 +99,7 @@
 
       <div class="ml-auto">
         <%= button_to "Destroy", sandbox_path(@sandbox), method: :delete,
-              data: { confirm: "Destroy #{@sandbox.name}? This cannot be undone." },
+              data: { confirm: "Destroy #{@sandbox.display_name}? This cannot be undone." },
               class: "px-3 py-1.5 bg-red-600 text-white text-sm rounded hover:bg-red-700 transition-colors" %>
       </div>
     </div>

--- a/test/models/sandbox_test.rb
+++ b/test/models/sandbox_test.rb
@@ -29,7 +29,7 @@ class SandboxTest < ActiveSupport::TestCase
     assert_equal "projects/demo", sandbox.project_path
   end
 
-  test "hostname and full_name include project name when present" do
+  test "hostname, full_name, and display_name include project name when present" do
     sandbox = @user.sandboxes.build(
       name: "testbox",
       project_name: "alpha",
@@ -39,6 +39,17 @@ class SandboxTest < ActiveSupport::TestCase
 
     assert_equal "testbox-alpha", sandbox.hostname
     assert_equal "alice-testbox-alpha", sandbox.full_name
+    assert_equal "alpha:testbox", sandbox.display_name
+  end
+
+  test "display_name falls back to name when project is absent" do
+    sandbox = @user.sandboxes.build(
+      name: "testbox",
+      status: "pending",
+      image: SandboxManager::DEFAULT_IMAGE
+    )
+
+    assert_equal "testbox", sandbox.display_name
   end
 
   test "name uniqueness is scoped per project" do


### PR DESCRIPTION
## Summary
Surface the project context in the user-facing sandbox name. Adds `Sandbox#display_name` returning `<project>:<name>` when a project is set (else just `<name>`), and uses it across the web UI:

- Dashboard active list (project shown as muted prefix)
- Sandbox show page heading + page title + destroy confirm
- Archived list
- Logs page heading + title
- Discover-files back link

The inline-rename field stays bound to `name` only — project assignment isn't part of the rename flow.

## Test plan
- [ ] `bin/rails test test/models/sandbox_test.rb` (covers display_name with/without project)
- [ ] Manual: dashboard shows `alpha:tmp` for a project-bound sandbox; just `tmp` for a project-less one
- [ ] Manual: rename a project-bound sandbox via inline edit — only the name part changes, project prefix stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sandbox naming display: sandboxes assigned to a project now show the project name as a prefix (e.g., "ProjectName:SandboxName") across the interface, including in the dashboard, sandbox details page, logs, and file browser.

* **Tests**
  * Added test coverage for the new sandbox display name formatting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->