### PR TITLE
fix(sandbox): web terminals start at $HOME, add ~/.local/bin to PATH

### DIFF
--- a/images/sandbox/Dockerfile.base
+++ b/images/sandbox/Dockerfile.base
@@ -162,6 +162,17 @@ RUN echo "MISE_DATA_DIR=/usr/local/share/mise" >> /etc/environment \
     && echo "alias ycodex='codex --dangerously-bypass-approvals-and-sandbox'" >> /etc/bash.bashrc \
     && echo "alias dps='docker ps --format \"table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.State}}\t{{.Status}}\"'" >> /etc/bash.bashrc
 
+# Prepend $HOME/.local/bin to PATH for every user. Home is bind-mounted from
+# the host so /etc/skel/.profile (Ubuntu's default) never lands in $HOME and
+# the user's local-bin would otherwise be off PATH. /etc/profile.d/ covers
+# login shells; the same line in /etc/bash.bashrc covers non-login interactive
+# bash shells.
+RUN printf 'case ":$PATH:" in *":$HOME/.local/bin:"*) ;; *) PATH="$HOME/.local/bin:$PATH" ;; esac\n' \
+        > /etc/profile.d/sandcastle-path.sh \
+    && chmod 0644 /etc/profile.d/sandcastle-path.sh \
+    && printf 'case ":$PATH:" in *":$HOME/.local/bin:"*) ;; *) PATH="$HOME/.local/bin:$PATH" ;; esac\n' \
+        >> /etc/bash.bashrc
+
 # SSH configuration (key-only auth) — use drop-in config for Ubuntu 25.10 compatibility
 # StrictModes no: the home dir is bind-mounted from the host.  Sysbox user-
 # namespace UID remapping means it appears owned by nobody (not the sandbox

--- a/images/sandbox/entrypoint.sh
+++ b/images/sandbox/entrypoint.sh
@@ -267,9 +267,13 @@ fi
 if command -v ttyd &>/dev/null; then
     touch /var/log/ttyd-tmux.log /var/log/ttyd-shell.log
     chown "$USERNAME:$USERNAME" /var/log/ttyd-tmux.log /var/log/ttyd-shell.log
-    su -s /bin/bash "$USERNAME" -c \
+    # `su -l` (login shell) so HOME is set and the spawned tmux/bash inherits
+    # cwd=$HOME instead of /. Without -l the cwd would be wherever entrypoint
+    # is running from (i.e. /), and the first tmux session would pin its
+    # initial window's cwd to /.
+    su -l -s /bin/bash "$USERNAME" -c \
         "ttyd -W -m 0 -p 7681 tmux new-session -A -s main &>/var/log/ttyd-tmux.log &"
-    su -s /bin/bash "$USERNAME" -c \
+    su -l -s /bin/bash "$USERNAME" -c \
         "ttyd -W -m 1 -p 7682 bash -l &>/var/log/ttyd-shell.log &"
 fi
 


### PR DESCRIPTION
## Summary
Two shell-environment fixes for the sandbox image:

**1. Web terminals start at `$HOME` instead of `/`**
- `entrypoint.sh` started ttyd via `su -s /bin/bash` (no `-l`), which keeps the parent process's cwd. The parent is the entrypoint, running with cwd=`/`.
- Worse: the first tmux session created on `port 7681` pinned its initial window's start-directory to `/`, so every subsequent attach (including SSH-via-WeTTY) landed there.
- Fix: `su -l -s /bin/bash` — login shell sets HOME and cd's to it before spawning ttyd.

**2. `$HOME/.local/bin` on PATH for all users**
- Home is bind-mounted from the host, so `/etc/skel/.profile` (Ubuntu's default home for the `if [ -d "$HOME/.local/bin" ]` rule) never lands in `$HOME`. User-installed binaries (mise shims, `claude`, etc.) were off-PATH for non-login shells.
- Fix: a `/etc/profile.d/sandcastle-path.sh` drop-in for login shells, plus the same line appended to `/etc/bash.bashrc` for non-login interactive bash.

## Test plan
- [ ] Rebuild sandbox base image, push to ghcr.io, pull on a host
- [ ] Open the web terminal — `pwd` shows `/home/<user>` (not `/`)
- [ ] In a fresh sandbox: `which claude` resolves to `~/.local/bin/claude` even in a non-login shell
- [ ] `bin/rails test` still green (201 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)