### PR TITLE
[codex] Add Sandcastle DNS resolver support

### DIFF
--- a/app/controllers/api/dns_controller.rb
+++ b/app/controllers/api/dns_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  class DnsController < BaseController
+    def status
+      render json: DnsManager.new.status(user: current_user)
+    end
+
+    def reconcile
+      manager = DnsManager.new
+      manager.publish(user: current_user)
+      manager.ensure_resolver(user: current_user)
+      render json: manager.status(user: current_user)
+    end
+  end
+end

--- a/app/controllers/api/sandboxes_controller.rb
+++ b/app/controllers/api/sandboxes_controller.rb
@@ -98,6 +98,7 @@ module Api
       end
 
       @sandbox.update!(sandbox_params)
+      DnsManager.publish_best_effort(@sandbox.user) if @sandbox.user.tailscale_enabled?
       render json: sandbox_json(@sandbox)
     end
 

--- a/app/jobs/container_sync_job.rb
+++ b/app/jobs/container_sync_job.rb
@@ -34,6 +34,12 @@ class ContainerSyncJob < ApplicationJob
     rescue => e
       Rails.logger.error("ContainerSyncJob: VNC cleanup failed: #{e.message}")
     end
+
+    begin
+      DnsManager.new.reconcile_all
+    rescue => e
+      Rails.logger.error("ContainerSyncJob: DNS reconcile failed: #{e.message}")
+    end
   end
 
   private

--- a/app/jobs/sandbox_destroy_job.rb
+++ b/app/jobs/sandbox_destroy_job.rb
@@ -16,7 +16,9 @@ class SandboxDestroyJob < ApplicationJob
     end
 
     begin
+      user = sandbox.user
       SandboxManager.new.destroy(sandbox: sandbox, archive: archive)
+      DnsManager.publish_best_effort(user) if user.tailscale_enabled?
       sandbox.finish_job
 
     rescue => e

--- a/app/jobs/sandbox_provision_job.rb
+++ b/app/jobs/sandbox_provision_job.rb
@@ -24,12 +24,14 @@ class SandboxProvisionJob < ApplicationJob
       end
 
       sandbox.update!(status: "running")
+      DnsManager.publish_best_effort(sandbox.user) if sandbox.user.tailscale_enabled?
       sandbox.finish_job
 
     rescue => e
       Rails.logger.error("SandboxProvisionJob failed: #{e.message}\n#{e.backtrace.join("\n")}")
       sandbox.fail_job("Failed to create: #{e.message}")
       sandbox.update!(status: "destroyed")
+      DnsManager.publish_best_effort(sandbox.user) if sandbox.user.tailscale_enabled?
 
       raise # Re-raise for Solid Queue retry
     end

--- a/app/jobs/sandbox_rebuild_job.rb
+++ b/app/jobs/sandbox_rebuild_job.rb
@@ -6,6 +6,7 @@ class SandboxRebuildJob < ApplicationJob
 
     begin
       SandboxManager.new.rebuild(sandbox: sandbox)
+      DnsManager.publish_best_effort(sandbox.user) if sandbox.user.tailscale_enabled?
       sandbox.finish_job
     rescue => e
       Rails.logger.error("SandboxRebuildJob failed: #{e.message}\n#{e.backtrace.join("\n")}")

--- a/app/jobs/sandbox_restore_job.rb
+++ b/app/jobs/sandbox_restore_job.rb
@@ -8,6 +8,7 @@ class SandboxRestoreJob < ApplicationJob
 
     begin
       SandboxManager.new.restore_from_archive(sandbox: sandbox)
+      DnsManager.publish_best_effort(sandbox.user) if sandbox.user.tailscale_enabled?
       sandbox.finish_job
     rescue => e
       Rails.logger.error("SandboxRestoreJob failed: #{e.message}\n#{e.backtrace.join("\n")}")

--- a/app/jobs/sandbox_start_job.rb
+++ b/app/jobs/sandbox_start_job.rb
@@ -7,6 +7,7 @@ class SandboxStartJob < ApplicationJob
 
     begin
       SandboxManager.new.start(sandbox: sandbox)
+      DnsManager.publish_best_effort(sandbox.user) if sandbox.user.tailscale_enabled?
       sandbox.finish_job
     rescue => e
       Rails.logger.error("SandboxStartJob failed: #{e.message}\n#{e.backtrace.join("\n")}")

--- a/app/jobs/sandbox_stop_job.rb
+++ b/app/jobs/sandbox_stop_job.rb
@@ -7,6 +7,7 @@ class SandboxStopJob < ApplicationJob
 
     begin
       SandboxManager.new.stop(sandbox: sandbox)
+      DnsManager.publish_best_effort(sandbox.user) if sandbox.user.tailscale_enabled?
       sandbox.finish_job
 
     rescue => e

--- a/app/services/dns_manager.rb
+++ b/app/services/dns_manager.rb
@@ -1,0 +1,262 @@
+require "fileutils"
+require "set"
+require "socket"
+
+class DnsManager
+  DATA_DIR = ENV.fetch("SANDCASTLE_DATA_DIR", "/data")
+  COREDNS_IMAGE = ENV.fetch("SANDCASTLE_DNS_IMAGE", "coredns/coredns:latest")
+
+  class Error < StandardError; end
+
+  Record = Struct.new(:name, :ip, :sandbox_id, keyword_init: true)
+  SkippedRecord = Struct.new(:name, :reason, :sandbox_id, keyword_init: true)
+
+  def self.publish_best_effort(user)
+    new.publish(user: user)
+  rescue => e
+    Rails.logger.warn("DnsManager: DNS publish for #{user.name} failed: #{e.message}")
+  end
+
+  def status(user:)
+    container = dns_container(user)
+    container_running = container&.json&.dig("State", "Running") == true
+
+    {
+      suffix: suffix,
+      network: user.tailscale_network,
+      tailscale_ip: tailscale_ip(user),
+      resolver_ip: resolver_ip(user),
+      resolver_container_id: container&.id&.[](0..11),
+      resolver_running: container_running,
+      hosts_path: hosts_path(user),
+      records: records_for(user).map { |r| { name: r.name, ip: r.ip, sandbox_id: r.sandbox_id } },
+      skipped: skipped_for(user).map { |r| { name: r.name, reason: r.reason, sandbox_id: r.sandbox_id } }
+    }
+  end
+
+  def reconcile_all
+    User.where(tailscale_state: "enabled").find_each do |user|
+      publish(user: user)
+      ensure_resolver(user: user)
+    rescue => e
+      Rails.logger.error("DnsManager: failed to reconcile DNS for #{user.name}: #{e.message}")
+    end
+  end
+
+  def publish(user:)
+    FileUtils.mkdir_p(dns_dir(user))
+    write_corefile(user)
+    write_hosts(user)
+  rescue => e
+    raise Error, "Failed to publish DNS for #{user.name}: #{e.message}"
+  end
+
+  def ensure_resolver(user:)
+    return nil unless user.tailscale_enabled?
+    return nil if user.tailscale_network.blank?
+
+    publish(user: user)
+    pull_image
+
+    existing = dns_container(user)
+    if existing
+      running = existing.json.dig("State", "Running")
+      return existing if running
+
+      existing.start
+      return existing
+    end
+
+    container = Docker::Container.create(
+      "Image" => COREDNS_IMAGE,
+      "name" => container_name(user),
+      "Cmd" => [ "-conf", "/data/Corefile" ],
+      "HostConfig" => {
+        "NetworkMode" => user.tailscale_network,
+        "Binds" => [ "#{dns_dir(user)}:/data:ro" ],
+        "RestartPolicy" => { "Name" => "unless-stopped" }
+      },
+      "Labels" => {
+        "sandcastle.dns" => "true",
+        "sandcastle.owner" => user.name
+      }
+    )
+    container.start
+    container
+  rescue Docker::Error::DockerError => e
+    raise Error, "Failed to ensure DNS resolver for #{user.name}: #{e.message}"
+  end
+
+  def cleanup(user)
+    container = dns_container(user)
+    return unless container
+
+    container.stop(t: 5) rescue nil
+    container.delete(force: true)
+  rescue Docker::Error::NotFoundError
+    nil
+  rescue Docker::Error::DockerError => e
+    Rails.logger.warn("DnsManager: failed to cleanup DNS resolver for #{user.name}: #{e.message}")
+  end
+
+  def suffix
+    name = ENV.fetch("SANDCASTLE_NAME", "").presence || Socket.gethostname
+    slug = dns_label(name)
+    slug.presence || "sandcastle"
+  end
+
+  private
+
+  def records_for(user)
+    records = []
+    seen = {}
+
+    dns_sandboxes(user).find_each do |sandbox|
+      ip = TailscaleManager.new.sandbox_tailscale_ip(sandbox: sandbox)
+      next if ip.blank?
+
+      name = fqdn_for(sandbox)
+      next if name.blank?
+
+      if seen.key?(name)
+        records.reject! { |r| r.name == name }
+        seen[name] = :duplicate
+        next
+      end
+
+      seen[name] = sandbox.id
+      records << Record.new(name: name, ip: ip, sandbox_id: sandbox.id)
+    end
+
+    records
+  end
+
+  def skipped_for(user)
+    skipped = []
+    names = Hash.new { |h, k| h[k] = [] }
+
+    dns_sandboxes(user).find_each do |sandbox|
+      name = fqdn_for(sandbox)
+      if name.blank?
+        skipped << SkippedRecord.new(name: sandbox.display_name, reason: "invalid DNS label", sandbox_id: sandbox.id)
+        next
+      end
+
+      ip = TailscaleManager.new.sandbox_tailscale_ip(sandbox: sandbox)
+      if ip.blank?
+        skipped << SkippedRecord.new(name: name, reason: "no Tailscale network IP", sandbox_id: sandbox.id)
+        next
+      end
+
+      names[name] << sandbox.id
+    end
+
+    names.each do |name, ids|
+      next unless ids.size > 1
+
+      ids.each do |id|
+        skipped << SkippedRecord.new(name: name, reason: "duplicate DNS name", sandbox_id: id)
+      end
+    end
+
+    skipped
+  end
+
+  def write_corefile(user)
+    content = <<~CORE
+      #{suffix}:53 {
+        hosts /data/hosts {
+          ttl 15
+          reload 5s
+          fallthrough
+        }
+        errors
+        log
+      }
+    CORE
+    atomic_write(corefile_path(user), content)
+  end
+
+  def dns_sandboxes(user)
+    user.sandboxes.running.where(tailscale: true)
+  end
+
+  def write_hosts(user)
+    skipped_ids = skipped_for(user).select { |r| r.reason == "duplicate DNS name" }.map(&:sandbox_id).to_set
+    lines = records_for(user).reject { |r| skipped_ids.include?(r.sandbox_id) }.map do |record|
+      "#{record.ip} #{record.name}"
+    end
+    atomic_write(hosts_path(user), "#{lines.join("\n")}\n")
+  end
+
+  def fqdn_for(sandbox)
+    sandbox_label = dns_label(sandbox.name)
+    project_label = dns_label(sandbox.project_name.presence || "sandboxes")
+    instance_label = suffix
+
+    return nil if sandbox_label.blank? || project_label.blank? || instance_label.blank?
+
+    "#{sandbox_label}.#{project_label}.#{instance_label}"
+  end
+
+  def dns_label(value)
+    label = value.to_s.downcase.tr("_", "-").gsub(/[^a-z0-9-]+/, "-").gsub(/\A-+|-+\z/, "")
+    return nil if label.blank? || label.length > 63
+    return nil unless label.match?(/\A[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z/)
+
+    label
+  end
+
+  def resolver_ip(user)
+    container = dns_container(user)
+    return nil unless container && user.tailscale_network.present?
+
+    container.json.dig("NetworkSettings", "Networks", user.tailscale_network, "IPAddress")
+  rescue Docker::Error::DockerError
+    nil
+  end
+
+  def tailscale_ip(user)
+    return nil if user.tailscale_container_id.blank?
+
+    container = Docker::Container.get(user.tailscale_container_id)
+    ip_out = container.exec([ "tailscale", "ip", "--4" ])
+    ip_out.first.first&.strip if ip_out.first.any?
+  rescue Docker::Error::DockerError
+    nil
+  end
+
+  def dns_container(user)
+    Docker::Container.get(container_name(user))
+  rescue Docker::Error::NotFoundError
+    nil
+  end
+
+  def pull_image
+    Docker::Image.get(COREDNS_IMAGE)
+  rescue Docker::Error::NotFoundError
+    Docker::Image.create("fromImage" => COREDNS_IMAGE)
+  end
+
+  def atomic_write(path, content)
+    tmp = "#{path}.tmp"
+    File.write(tmp, content)
+    File.rename(tmp, path)
+  end
+
+  def dns_dir(user)
+    File.join(DATA_DIR, "users", user.name, "dns")
+  end
+
+  def hosts_path(user)
+    File.join(dns_dir(user), "hosts")
+  end
+
+  def corefile_path(user)
+    File.join(dns_dir(user), "Corefile")
+  end
+
+  def container_name(user)
+    "sc-dns-#{user.name}"
+  end
+end

--- a/app/services/tailscale_manager.rb
+++ b/app/services/tailscale_manager.rb
@@ -62,6 +62,7 @@ class TailscaleManager
       tailscale_network: network_name,
       tailscale_subnet: subnet
     )
+    ensure_dns_resolver(user)
     user
   rescue Docker::Error::DockerError => e
     cleanup_on_failure(user)
@@ -81,6 +82,7 @@ class TailscaleManager
       tailscale_network: network_name
     )
     save_auth_key(user, auth_key)
+    ensure_dns_resolver(user)
     user
   rescue Docker::Error::DockerError => e
     cleanup_on_failure(user)
@@ -145,6 +147,7 @@ class TailscaleManager
       when "Running"
         Rails.cache.delete(cache_key)
         user.update!(tailscale_state: "enabled", tailscale_auto_connect: true)
+        ensure_dns_resolver(user)
         ip_out = container.exec([ "tailscale", "ip", "--4" ])
         tailscale_ip = ip_out.first.first&.strip if ip_out.first.any?
         return {
@@ -182,6 +185,7 @@ class TailscaleManager
       disconnect_sandbox(sandbox: sandbox)
     end
 
+    cleanup_dns_resolver(user)
     cleanup_sidecar(user)
 
     user.update!(
@@ -273,6 +277,7 @@ class TailscaleManager
     end
 
     sandbox.update!(tailscale: true)
+    ensure_dns_resolver(user)
     sandbox
   rescue Error
     raise
@@ -294,6 +299,7 @@ class TailscaleManager
     end
 
     sandbox.update!(tailscale: false)
+    publish_dns(user) if user.tailscale_enabled?
     sandbox
   rescue Docker::Error::DockerError => e
     raise Error, "Failed to disconnect sandbox from Tailscale: #{e.message}"
@@ -320,6 +326,24 @@ class TailscaleManager
     FileUtils.mkdir_p(File.dirname(path))
     File.write(path, auth_key)
     File.chmod(0o600, path)
+  end
+
+  def ensure_dns_resolver(user)
+    DnsManager.new.ensure_resolver(user: user)
+  rescue => e
+    Rails.logger.warn("TailscaleManager: DNS resolver setup for #{user.name} failed: #{e.message}")
+  end
+
+  def publish_dns(user)
+    DnsManager.new.publish(user: user)
+  rescue => e
+    Rails.logger.warn("TailscaleManager: DNS publish for #{user.name} failed: #{e.message}")
+  end
+
+  def cleanup_dns_resolver(user)
+    DnsManager.new.cleanup(user)
+  rescue => e
+    Rails.logger.warn("TailscaleManager: DNS cleanup for #{user.name} failed: #{e.message}")
   end
 
   def delete_auth_key(user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,10 @@ Rails.application.routes.draw do
     resource :smb, only: [], controller: "smb" do
       patch :set_password
     end
+    resource :dns, only: [], controller: "dns" do
+      get :status
+      post :reconcile
+    end
     resources :gcp_oidc_configs, only: [ :index, :show, :create, :update, :destroy ]
   end
 

--- a/vendor/sandcastle-cli/api/client.go
+++ b/vendor/sandcastle-cli/api/client.go
@@ -551,6 +551,20 @@ func (c *Client) TailscaleDisconnect(sandboxID int) (*Sandbox, error) {
 	return &s, err
 }
 
+// DNS
+
+func (c *Client) DNSStatus() (*DNSStatus, error) {
+	var s DNSStatus
+	err := c.do("GET", "/api/dns/status", nil, &s)
+	return &s, err
+}
+
+func (c *Client) DNSReconcile() (*DNSStatus, error) {
+	var s DNSStatus
+	err := c.do("POST", "/api/dns/reconcile", nil, &s)
+	return &s, err
+}
+
 // SMB
 
 func (c *Client) SmbSetPassword(password string) error {

--- a/vendor/sandcastle-cli/api/types.go
+++ b/vendor/sandcastle-cli/api/types.go
@@ -414,6 +414,30 @@ type TailscaleSandbox struct {
 	IP   string `json:"ip"`
 }
 
+type DNSStatus struct {
+	Suffix              string      `json:"suffix"`
+	Network             string      `json:"network"`
+	TailscaleIP         string      `json:"tailscale_ip"`
+	ResolverIP          string      `json:"resolver_ip"`
+	ResolverContainerID string      `json:"resolver_container_id"`
+	ResolverRunning     bool        `json:"resolver_running"`
+	HostsPath           string      `json:"hosts_path"`
+	Records             []DNSRecord `json:"records"`
+	Skipped             []DNSSkip   `json:"skipped"`
+}
+
+type DNSRecord struct {
+	Name      string `json:"name"`
+	IP        string `json:"ip"`
+	SandboxID int    `json:"sandbox_id"`
+}
+
+type DNSSkip struct {
+	Name      string `json:"name"`
+	Reason    string `json:"reason"`
+	SandboxID int    `json:"sandbox_id"`
+}
+
 type APIError struct {
 	Error string `json:"error"`
 }

--- a/vendor/sandcastle-cli/cmd/dns.go
+++ b/vendor/sandcastle-cli/cmd/dns.go
@@ -1,0 +1,581 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/sandcastle/cli/api"
+	"github.com/sandcastle/cli/internal/config"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const resolverMarker = "# Managed by sandcastle dns"
+
+var (
+	dnsInstallSearch bool
+	dnsSearchProject string
+	dnsSearchService string
+	dnsSearchAll     bool
+)
+
+type dnsState struct {
+	Search map[string]map[string]managedSearchDomain `yaml:"search,omitempty"`
+}
+
+type managedSearchDomain struct {
+	AddedBySandcastle bool `yaml:"added_by_sandcastle"`
+}
+
+func init() {
+	rootCmd.AddCommand(dnsCmd)
+	dnsCmd.AddCommand(dnsStatusCmd)
+	dnsCmd.AddCommand(dnsInstallCmd)
+	dnsCmd.AddCommand(dnsUninstallCmd)
+	dnsCmd.AddCommand(dnsSearchCmd)
+
+	dnsInstallCmd.Flags().BoolVar(&dnsInstallSearch, "search", false, "Also add the instance suffix to the macOS DNS search path")
+
+	dnsSearchCmd.AddCommand(dnsSearchStatusCmd)
+	dnsSearchCmd.AddCommand(dnsSearchAddCmd)
+	dnsSearchCmd.AddCommand(dnsSearchRemoveCmd)
+
+	for _, c := range []*cobra.Command{dnsSearchAddCmd, dnsSearchRemoveCmd} {
+		c.Flags().StringVar(&dnsSearchProject, "project", "", "Manage project search suffix (<project>.<instance>)")
+		c.Flags().StringVar(&dnsSearchService, "service", "", "macOS network service to update")
+		c.Flags().BoolVar(&dnsSearchAll, "all-enabled", false, "Update all enabled macOS network services")
+	}
+	dnsSearchStatusCmd.Flags().StringVar(&dnsSearchService, "service", "", "macOS network service to inspect")
+	dnsSearchStatusCmd.Flags().BoolVar(&dnsSearchAll, "all-enabled", false, "Inspect all enabled macOS network services")
+}
+
+var dnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "Manage Sandcastle DNS on this client",
+}
+
+var dnsStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show Sandcastle DNS status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+		printServer(client)
+
+		status, err := client.DNSStatus()
+		if err != nil {
+			return err
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "Suffix:\t%s\n", valueOrDash(status.Suffix))
+		fmt.Fprintf(w, "Resolver IP:\t%s\n", valueOrDash(status.ResolverIP))
+		fmt.Fprintf(w, "Tailscale IP:\t%s\n", valueOrDash(status.TailscaleIP))
+		fmt.Fprintf(w, "Resolver running:\t%t\n", status.ResolverRunning)
+		fmt.Fprintf(w, "Network:\t%s\n", valueOrDash(status.Network))
+		fmt.Fprintf(w, "Hosts file:\t%s\n", valueOrDash(status.HostsPath))
+		if runtime.GOOS == "darwin" && status.Suffix != "" {
+			fmt.Fprintf(w, "macOS resolver:\t%s\n", resolverStatus(status.Suffix))
+		}
+		w.Flush()
+
+		if len(status.Records) > 0 {
+			fmt.Println()
+			w = tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tIP")
+			for _, r := range status.Records {
+				fmt.Fprintf(w, "%s\t%s\n", r.Name, r.IP)
+			}
+			w.Flush()
+		}
+
+		if len(status.Skipped) > 0 {
+			fmt.Println()
+			w = tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "SKIPPED\tREASON")
+			for _, s := range status.Skipped {
+				fmt.Fprintf(w, "%s\t%s\n", s.Name, s.Reason)
+			}
+			w.Flush()
+		}
+		return nil
+	},
+}
+
+var dnsInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install macOS resolver configuration for Sandcastle DNS",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireDarwin(); err != nil {
+			return err
+		}
+
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+		printServer(client)
+
+		status, err := client.DNSReconcile()
+		if err != nil {
+			return err
+		}
+		if status.Suffix == "" {
+			return fmt.Errorf("server did not return a DNS suffix")
+		}
+		if status.ResolverIP == "" {
+			return fmt.Errorf("DNS resolver IP is not available; enable Tailscale and approve subnet routes first")
+		}
+
+		if err := installResolver(status.Suffix, status.ResolverIP); err != nil {
+			return err
+		}
+		fmt.Printf("Installed /etc/resolver/%s -> %s\n", status.Suffix, status.ResolverIP)
+
+		if dnsInstallSearch {
+			if err := addSearchDomain(status.Suffix); err != nil {
+				return err
+			}
+			fmt.Printf("Added search domain %s\n", status.Suffix)
+		}
+		return nil
+	},
+}
+
+var dnsUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Remove Sandcastle macOS resolver configuration",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireDarwin(); err != nil {
+			return err
+		}
+
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+		status, err := client.DNSStatus()
+		if err != nil {
+			return err
+		}
+		if status.Suffix == "" {
+			return fmt.Errorf("server did not return a DNS suffix")
+		}
+		if err := uninstallResolver(status.Suffix); err != nil {
+			return err
+		}
+		fmt.Printf("Removed /etc/resolver/%s\n", status.Suffix)
+		return nil
+	},
+}
+
+var dnsSearchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Manage macOS DNS search domains for Sandcastle",
+}
+
+var dnsSearchStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show macOS DNS search domains",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireDarwin(); err != nil {
+			return err
+		}
+
+		services, err := targetServices()
+		if err != nil {
+			return err
+		}
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "SERVICE\tSEARCH DOMAINS")
+		for _, service := range services {
+			domains, err := getSearchDomains(service)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%s\t%s\n", service, displayDomains(domains))
+		}
+		return w.Flush()
+	},
+}
+
+var dnsSearchAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add Sandcastle DNS suffix to the macOS search path",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireDarwin(); err != nil {
+			return err
+		}
+
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+		status, err := client.DNSStatus()
+		if err != nil {
+			return err
+		}
+		if status.Suffix == "" {
+			return fmt.Errorf("server did not return a DNS suffix")
+		}
+		domain, err := searchDomain(status.Suffix)
+		if err != nil {
+			return err
+		}
+		if err := addSearchDomain(domain); err != nil {
+			return err
+		}
+		fmt.Printf("Added search domain %s\n", domain)
+		return nil
+	},
+}
+
+var dnsSearchRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove Sandcastle-managed DNS suffix from the macOS search path",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireDarwin(); err != nil {
+			return err
+		}
+
+		client, err := api.NewClient()
+		if err != nil {
+			return err
+		}
+		status, err := client.DNSStatus()
+		if err != nil {
+			return err
+		}
+		if status.Suffix == "" {
+			return fmt.Errorf("server did not return a DNS suffix")
+		}
+		domain, err := searchDomain(status.Suffix)
+		if err != nil {
+			return err
+		}
+		if err := removeSearchDomain(domain); err != nil {
+			return err
+		}
+		fmt.Printf("Removed Sandcastle-managed search domain %s\n", domain)
+		return nil
+	},
+}
+
+func requireDarwin() error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("this command currently supports macOS only")
+	}
+	return nil
+}
+
+func searchDomain(instance string) (string, error) {
+	if dnsSearchProject == "" {
+		return instance, nil
+	}
+	project := dnsLabel(dnsSearchProject)
+	if project == "" {
+		return "", fmt.Errorf("invalid project DNS label %q", dnsSearchProject)
+	}
+	return project + "." + instance, nil
+}
+
+func dnsLabel(s string) string {
+	return strings.Trim(strings.ToLower(strings.ReplaceAll(s, "_", "-")), ".")
+}
+
+func installResolver(suffix, resolverIP string) error {
+	content := fmt.Sprintf("%s\n# Server: %s\nnameserver %s\n", resolverMarker, suffix, resolverIP)
+	tmp, err := os.CreateTemp("", "sandcastle-resolver-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(content); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := run("sudo", "mkdir", "-p", "/etc/resolver"); err != nil {
+		return err
+	}
+	return run("sudo", "cp", tmp.Name(), resolverPath(suffix))
+}
+
+func uninstallResolver(suffix string) error {
+	path := resolverPath(suffix)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !strings.Contains(string(data), resolverMarker) {
+		return fmt.Errorf("%s is not managed by Sandcastle; refusing to remove", path)
+	}
+	return run("sudo", "rm", "-f", path)
+}
+
+func resolverStatus(suffix string) string {
+	data, err := os.ReadFile(resolverPath(suffix))
+	if err != nil {
+		return "not installed"
+	}
+	if strings.Contains(string(data), resolverMarker) {
+		return "installed"
+	}
+	return "exists, not managed by Sandcastle"
+}
+
+func resolverPath(suffix string) string {
+	return filepath.Join("/etc/resolver", suffix)
+}
+
+func addSearchDomain(domain string) error {
+	state, err := loadDNSState()
+	if err != nil {
+		return err
+	}
+	services, err := targetServices()
+	if err != nil {
+		return err
+	}
+	for _, service := range services {
+		domains, err := getSearchDomains(service)
+		if err != nil {
+			return err
+		}
+		already := contains(domains, domain)
+		if !already {
+			domains = append(domains, domain)
+			if err := setSearchDomains(service, domains); err != nil {
+				return err
+			}
+		}
+		rememberSearchDomain(state, service, domain, !already)
+	}
+	return saveDNSState(state)
+}
+
+func removeSearchDomain(domain string) error {
+	state, err := loadDNSState()
+	if err != nil {
+		return err
+	}
+	services, err := targetServices()
+	if err != nil {
+		return err
+	}
+	for _, service := range services {
+		managed, ok := state.Search[service][domain]
+		if !ok || !managed.AddedBySandcastle {
+			continue
+		}
+		domains, err := getSearchDomains(service)
+		if err != nil {
+			return err
+		}
+		next := removeDomain(domains, domain)
+		if err := setSearchDomains(service, next); err != nil {
+			return err
+		}
+		delete(state.Search[service], domain)
+	}
+	return saveDNSState(state)
+}
+
+func rememberSearchDomain(state *dnsState, service, domain string, added bool) {
+	if state.Search == nil {
+		state.Search = make(map[string]map[string]managedSearchDomain)
+	}
+	if state.Search[service] == nil {
+		state.Search[service] = make(map[string]managedSearchDomain)
+	}
+	state.Search[service][domain] = managedSearchDomain{AddedBySandcastle: added}
+}
+
+func targetServices() ([]string, error) {
+	if dnsSearchService != "" {
+		return []string{dnsSearchService}, nil
+	}
+	services, err := listNetworkServices()
+	if err != nil {
+		return nil, err
+	}
+	if dnsSearchAll {
+		return services, nil
+	}
+	if len(services) == 0 {
+		return nil, fmt.Errorf("no enabled macOS network services found")
+	}
+	return []string{services[0]}, nil
+}
+
+func listNetworkServices() ([]string, error) {
+	ordered, err := listNetworkServiceOrder()
+	if err == nil && len(ordered) > 0 {
+		return ordered, nil
+	}
+
+	out, err := exec.Command("/usr/sbin/networksetup", "-listallnetworkservices").Output()
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+	var services []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "An asterisk") || strings.HasPrefix(line, "*") {
+			continue
+		}
+		services = append(services, line)
+	}
+	return services, nil
+}
+
+func listNetworkServiceOrder() ([]string, error) {
+	out, err := exec.Command("/usr/sbin/networksetup", "-listnetworkserviceorder").Output()
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+	var services []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "(") {
+			continue
+		}
+		end := strings.Index(line, ") ")
+		if end < 0 || end+2 >= len(line) {
+			continue
+		}
+		name := strings.TrimSpace(line[end+2:])
+		if name == "" || strings.HasPrefix(name, "*") || strings.HasPrefix(name, "Hardware Port:") {
+			continue
+		}
+		services = append(services, name)
+	}
+	return services, nil
+}
+
+func getSearchDomains(service string) ([]string, error) {
+	out, err := exec.Command("/usr/sbin/networksetup", "-getsearchdomains", service).Output()
+	if err != nil {
+		return nil, err
+	}
+	text := strings.TrimSpace(string(out))
+	if text == "" || strings.Contains(text, "There aren't any Search Domains") {
+		return nil, nil
+	}
+	return strings.Fields(text), nil
+}
+
+func setSearchDomains(service string, domains []string) error {
+	args := []string{"/usr/sbin/networksetup", "-setsearchdomains", service}
+	if len(domains) == 0 {
+		args = append(args, "Empty")
+	} else {
+		args = append(args, domains...)
+	}
+	fmt.Printf("Running: sudo %s\n", strings.Join(shellQuote(args), " "))
+	return run("sudo", args...)
+}
+
+func loadDNSState() (*dnsState, error) {
+	state := &dnsState{Search: make(map[string]map[string]managedSearchDomain)}
+	data, err := os.ReadFile(dnsStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state, nil
+		}
+		return nil, err
+	}
+	if err := yaml.Unmarshal(data, state); err != nil {
+		return nil, err
+	}
+	if state.Search == nil {
+		state.Search = make(map[string]map[string]managedSearchDomain)
+	}
+	return state, nil
+}
+
+func saveDNSState(state *dnsState) error {
+	if err := os.MkdirAll(config.Dir(), 0o700); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dnsStatePath(), data, 0o600)
+}
+
+func dnsStatePath() string {
+	return filepath.Join(config.Dir(), "dns.yaml")
+}
+
+func contains(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeDomain(items []string, target string) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item != target {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func displayDomains(domains []string) string {
+	if len(domains) == 0 {
+		return "—"
+	}
+	sort.Strings(domains)
+	return strings.Join(domains, ", ")
+}
+
+func shellQuote(args []string) []string {
+	out := make([]string, len(args))
+	for i, arg := range args {
+		if strings.ContainsAny(arg, " \t\n'\"") {
+			out[i] = "'" + strings.ReplaceAll(arg, "'", "'\\''") + "'"
+		} else {
+			out[i] = arg
+		}
+	}
+	return out
+}
+
+func run(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return fmt.Errorf("%s: %w", msg, err)
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds Sandcastle-managed DNS for Tailscale-enabled sandboxes.

- Adds API endpoints for DNS status and reconcile.
- Publishes CoreDNS hosts records for running Tailscale-connected sandboxes.
- Starts and cleans up a per-user CoreDNS resolver container on each user's Tailscale network.
- Hooks DNS publishing into sandbox lifecycle jobs and Tailscale connect/disconnect flows.
- Adds CLI `dns` commands for status, macOS resolver install/uninstall, and macOS DNS search domain management.

## Impact

Users with Tailscale enabled can resolve sandbox names through a Sandcastle-managed DNS suffix. The CLI can install the macOS `/etc/resolver` entry and optionally manage DNS search domains.

## Validation

- `go test ./...` in `vendor/sandcastle-cli`
- `git diff --check HEAD~1..HEAD`

Rails tests were not run because `bin/rails test` cannot start in this environment: `/usr/bin/env: 'ruby': No such file or directory`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoints to check DNS status and manually trigger DNS reconciliation for Tailscale-enabled users.
  * Integrated automatic DNS management into sandbox operations (provision, start, stop, rebuild, restore, and destroy).
  * Added new macOS CLI commands for DNS resolver configuration and search domain management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->