### PR TITLE
[codex] Fix project path OIDC inheritance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,14 @@ Go module path is `github.com/sandcastle/cli`. When adding a new feature: add ty
 To apply a single file change directly to the running production instance without a full redeploy:
 
 ```bash
-scp path/to/file.rb sandcastle@sandman:/tmp/file.rb
-ssh sandcastle@sandman 'docker cp /tmp/file.rb sandcastle-web:/rails/path/to/file.rb && docker restart sandcastle-web'
+ssh sandcastle@sandman 'mkdir -p "$SANDCASTLE_HOME/tmp"'
+scp path/to/file.rb sandcastle@sandman:'$SANDCASTLE_HOME/tmp/file.rb'
+ssh sandcastle@sandman 'docker cp "$SANDCASTLE_HOME/tmp/file.rb" sandcastle-web:/rails/path/to/file.rb && rm -f "$SANDCASTLE_HOME/tmp/file.rb" && docker restart sandcastle-web'
 ```
+
+All Sandcastle-owned host files, including temporary hotfix or installer scratch files, must live under `$SANDCASTLE_HOME`; do not stage Sandcastle files in host-global `/tmp`.
+
+Dockyard changes live in the sibling `../dockyard` repository. When changing `dockyard.sh` behavior, edit `../dockyard/src/*.sh`, build it there, and commit/push through Dockyard's git history; do not directly edit the vendored/generated Dockyard script in this repo.
 
 ### Full CI
 

--- a/app/controllers/api/sandboxes_controller.rb
+++ b/app/controllers/api/sandboxes_controller.rb
@@ -356,7 +356,10 @@ module Api
     end
 
     def resolve_project(project_path:)
-      return nil if project_path.present?
+      if project_path.present?
+        return current_user.projects.find_by(name: project_path) ||
+          current_user.projects.find_by(path: project_path)
+      end
       return current_user.projects.find(params[:project_id]) if params[:project_id].present?
       return current_user.projects.find_by!(name: params[:project_name]) if params[:project_name].present?
 
@@ -365,12 +368,13 @@ module Api
 
     def apply_project_defaults(sandbox, project, project_path:)
       if project_path.present?
-        defaults = current_user.default_project
+        defaults = project || current_user.default_project
         defaults.apply_to_sandbox(sandbox)
-        sandbox.project_name = File.basename(project_path)
+        scoped_path = project&.path.presence || project_path
+        sandbox.project_name = project&.name.presence || File.basename(project_path)
         sandbox.mount_home = false
-        sandbox.home_path = project_path
-        sandbox.data_path = project_path
+        sandbox.home_path = scoped_path
+        sandbox.data_path = scoped_path
         sandbox.tailscale = boolean_param(:tailscale, defaults.tailscale)
         sandbox.vnc_enabled = boolean_param(:vnc_enabled, defaults.vnc_enabled)
         sandbox.vnc_geometry = params[:vnc_geometry].presence || defaults.vnc_geometry

--- a/app/controllers/sandboxes_controller.rb
+++ b/app/controllers/sandboxes_controller.rb
@@ -348,7 +348,10 @@ class SandboxesController < ApplicationController
   end
 
   def resolve_project(project_path:)
-    return nil if project_path.present?
+    if project_path.present?
+      return Current.user.projects.find_by(name: project_path) ||
+        Current.user.projects.find_by(path: project_path)
+    end
     return Current.user.projects.find(params[:project_id]) if params[:project_id].present?
 
     Current.user.default_project
@@ -356,11 +359,13 @@ class SandboxesController < ApplicationController
 
   def apply_project_defaults(sandbox, project, project_path:)
     if project_path.present?
-      Current.user.default_project.apply_to_sandbox(sandbox)
-      sandbox.project_name = File.basename(project_path)
+      defaults = project || Current.user.default_project
+      defaults.apply_to_sandbox(sandbox)
+      scoped_path = project&.path.presence || project_path
+      sandbox.project_name = project&.name.presence || File.basename(project_path)
       sandbox.mount_home = false
-      sandbox.home_path = project_path
-      sandbox.data_path = project_path
+      sandbox.home_path = scoped_path
+      sandbox.data_path = scoped_path
       sandbox.tailscale = params[:tailscale] == "1"
       sandbox.vnc_enabled = params[:vnc_enabled] != "0"
       sandbox.vnc_geometry = Sandbox::VNC_GEOMETRIES.include?(params[:vnc_geometry]) ? params[:vnc_geometry] : "1280x900"

--- a/installer.sh
+++ b/installer.sh
@@ -371,8 +371,9 @@ cmd_backup() {
   local default_output="./sandcastle-backup-${timestamp}-${version}.tar.zst"
   output="${output:-$default_output}"
 
+  mkdir -p "$SANDCASTLE_HOME/tmp"
   local work_dir
-  work_dir=$(mktemp -d)
+  work_dir=$(mktemp -d "$SANDCASTLE_HOME/tmp/backup.XXXXXX")
   trap "rm -rf '$work_dir'" EXIT
 
   local backup_dir="$work_dir/sandcastle-backup"
@@ -554,8 +555,9 @@ cmd_restore() {
 
   # ── Read and validate manifest ────────────────────────────────────────────
 
+  mkdir -p "$SANDCASTLE_HOME/tmp"
   local work_dir
-  work_dir=$(mktemp -d)
+  work_dir=$(mktemp -d "$SANDCASTLE_HOME/tmp/restore.XXXXXX")
   trap "rm -rf '$work_dir'" EXIT
 
   info "Reading backup manifest..."
@@ -1097,9 +1099,11 @@ install_mkcert() {
 
 # ═══ write_compose ══════════════════════════════════════════════════════════
 
-# Write the bundled dockyard.sh to /tmp so it can be invoked without wget.
+# Write the bundled dockyard.sh under SANDCASTLE_HOME so it can be invoked
+# without leaving Sandcastle-owned files in host-global temporary paths.
 write_dockyard_sh() {
-  cat > /tmp/dockyard.sh <<'__DOCKYARD_BUNDLED_EOF__'
+  mkdir -p "$SANDCASTLE_HOME/tmp"
+  cat > "$SANDCASTLE_HOME/tmp/dockyard.sh" <<'__DOCKYARD_BUNDLED_EOF__'
 #!/bin/bash
 set -euo pipefail
 
@@ -2876,7 +2880,7 @@ case "$COMMAND" in
 esac
 
 __DOCKYARD_BUNDLED_EOF__
-  chmod +x /tmp/dockyard.sh
+  chmod +x "$SANDCASTLE_HOME/tmp/dockyard.sh"
 }
 
 write_helper_scripts() {
@@ -3225,8 +3229,8 @@ cmd_destroy() {
   if [ -n "$DOCKYARD_ENV_FILE" ] || systemctl cat "${DOCKYARD_DOCKER_PREFIX}docker.service" &>/dev/null; then
     info "Destroying Dockyard..."
     if [ -n "$DOCKYARD_ENV_FILE" ] && write_dockyard_sh 2>/dev/null; then
-      DOCKYARD_ENV="$DOCKYARD_ENV_FILE" bash /tmp/dockyard.sh destroy --yes --keep-data 2>&1 || true
-      rm -f /tmp/dockyard.sh
+      DOCKYARD_ENV="$DOCKYARD_ENV_FILE" bash "$SANDCASTLE_HOME/tmp/dockyard.sh" destroy --yes --keep-data 2>&1 || true
+      rm -f "$SANDCASTLE_HOME/tmp/dockyard.sh"
     else
       systemctl stop "${DOCKYARD_DOCKER_PREFIX}docker" 2>/dev/null || true
       systemctl disable "${DOCKYARD_DOCKER_PREFIX}docker" 2>/dev/null || true
@@ -3379,8 +3383,8 @@ DOCKYARD_POOL_SIZE=${DOCKYARD_POOL_SIZE}
 DYEOF
     wrote "$_dy_env"
 
-    DOCKYARD_ENV="$_dy_env" bash /tmp/dockyard.sh create
-    rm -f /tmp/dockyard.sh
+    DOCKYARD_ENV="$_dy_env" bash "$SANDCASTLE_HOME/tmp/dockyard.sh" create
+    rm -f "$SANDCASTLE_HOME/tmp/dockyard.sh"
 
     for i in $(seq 1 30); do
       [ -S "$DOCKER_SOCK" ] && break
@@ -3482,8 +3486,9 @@ DYEOF
       # ── Extract secrets from the backup file ──────────────────────────────
       # Pull just the secrets files from the archive without extracting everything.
       info "Extracting secrets from backup..."
+      mkdir -p "$SANDCASTLE_HOME/tmp"
       local _bk_work
-      _bk_work=$(mktemp -d)
+      _bk_work=$(mktemp -d "$SANDCASTLE_HOME/tmp/install-restore.XXXXXX")
       trap 'rm -rf "$_bk_work"' EXIT
       tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_bk_work" \
         sandcastle-backup/secrets/rails.secrets \
@@ -3981,8 +3986,9 @@ INITDB
     $DOCKER compose up -d
 
     # Load snapshot images now that the Dockyard daemon is fully up
+    mkdir -p "$SANDCASTLE_HOME/tmp"
     local _tmp_bk
-    _tmp_bk=$(mktemp -d)
+    _tmp_bk=$(mktemp -d "$SANDCASTLE_HOME/tmp/snapshot-images.XXXXXX")
     tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_tmp_bk" \
       sandcastle-backup/images 2>/dev/null || true
     if [ -d "$_tmp_bk/sandcastle-backup/images" ]; then

--- a/installer/installer.sh.in
+++ b/installer/installer.sh.in
@@ -499,12 +499,14 @@ install_mkcert() {
 
 # ═══ write_compose ══════════════════════════════════════════════════════════
 
-# Write the bundled dockyard.sh to /tmp so it can be invoked without wget.
+# Write the bundled dockyard.sh under SANDCASTLE_HOME so it can be invoked
+# without leaving Sandcastle-owned files in host-global temporary paths.
 write_dockyard_sh() {
-  cat > /tmp/dockyard.sh <<'__DOCKYARD_BUNDLED_EOF__'
+  mkdir -p "$SANDCASTLE_HOME/tmp"
+  cat > "$SANDCASTLE_HOME/tmp/dockyard.sh" <<'__DOCKYARD_BUNDLED_EOF__'
 @@TEMPLATE:templates/dockyard.sh@@
 __DOCKYARD_BUNDLED_EOF__
-  chmod +x /tmp/dockyard.sh
+  chmod +x "$SANDCASTLE_HOME/tmp/dockyard.sh"
 }
 
 write_helper_scripts() {
@@ -707,8 +709,8 @@ cmd_destroy() {
   if [ -n "$DOCKYARD_ENV_FILE" ] || systemctl cat "${DOCKYARD_DOCKER_PREFIX}docker.service" &>/dev/null; then
     info "Destroying Dockyard..."
     if [ -n "$DOCKYARD_ENV_FILE" ] && write_dockyard_sh 2>/dev/null; then
-      DOCKYARD_ENV="$DOCKYARD_ENV_FILE" bash /tmp/dockyard.sh destroy --yes --keep-data 2>&1 || true
-      rm -f /tmp/dockyard.sh
+      DOCKYARD_ENV="$DOCKYARD_ENV_FILE" bash "$SANDCASTLE_HOME/tmp/dockyard.sh" destroy --yes --keep-data 2>&1 || true
+      rm -f "$SANDCASTLE_HOME/tmp/dockyard.sh"
     else
       systemctl stop "${DOCKYARD_DOCKER_PREFIX}docker" 2>/dev/null || true
       systemctl disable "${DOCKYARD_DOCKER_PREFIX}docker" 2>/dev/null || true
@@ -861,8 +863,8 @@ DOCKYARD_POOL_SIZE=${DOCKYARD_POOL_SIZE}
 DYEOF
     wrote "$_dy_env"
 
-    DOCKYARD_ENV="$_dy_env" bash /tmp/dockyard.sh create
-    rm -f /tmp/dockyard.sh
+    DOCKYARD_ENV="$_dy_env" bash "$SANDCASTLE_HOME/tmp/dockyard.sh" create
+    rm -f "$SANDCASTLE_HOME/tmp/dockyard.sh"
 
     for i in $(seq 1 30); do
       [ -S "$DOCKER_SOCK" ] && break
@@ -964,8 +966,9 @@ DYEOF
       # ── Extract secrets from the backup file ──────────────────────────────
       # Pull just the secrets files from the archive without extracting everything.
       info "Extracting secrets from backup..."
+      mkdir -p "$SANDCASTLE_HOME/tmp"
       local _bk_work
-      _bk_work=$(mktemp -d)
+      _bk_work=$(mktemp -d "$SANDCASTLE_HOME/tmp/install-restore.XXXXXX")
       trap 'rm -rf "$_bk_work"' EXIT
       tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_bk_work" \
         sandcastle-backup/secrets/rails.secrets \
@@ -1450,8 +1453,9 @@ INITDB
     $DOCKER compose up -d
 
     # Load snapshot images now that the Dockyard daemon is fully up
+    mkdir -p "$SANDCASTLE_HOME/tmp"
     local _tmp_bk
-    _tmp_bk=$(mktemp -d)
+    _tmp_bk=$(mktemp -d "$SANDCASTLE_HOME/tmp/snapshot-images.XXXXXX")
     tar --use-compress-program=zstd -xf "$BACKUP_FILE" -C "$_tmp_bk" \
       sandcastle-backup/images 2>/dev/null || true
     if [ -d "$_tmp_bk/sandcastle-backup/images" ]; then

--- a/installer/templates/sandcastle-admin.sh
+++ b/installer/templates/sandcastle-admin.sh
@@ -98,8 +98,9 @@ cmd_backup() {
   local default_output="./sandcastle-backup-${timestamp}-${version}.tar.zst"
   output="${output:-$default_output}"
 
+  mkdir -p "$SANDCASTLE_HOME/tmp"
   local work_dir
-  work_dir=$(mktemp -d)
+  work_dir=$(mktemp -d "$SANDCASTLE_HOME/tmp/backup.XXXXXX")
   trap "rm -rf '$work_dir'" EXIT
 
   local backup_dir="$work_dir/sandcastle-backup"
@@ -281,8 +282,9 @@ cmd_restore() {
 
   # ── Read and validate manifest ────────────────────────────────────────────
 
+  mkdir -p "$SANDCASTLE_HOME/tmp"
   local work_dir
-  work_dir=$(mktemp -d)
+  work_dir=$(mktemp -d "$SANDCASTLE_HOME/tmp/restore.XXXXXX")
   trap "rm -rf '$work_dir'" EXIT
 
   info "Reading backup manifest..."

--- a/test/controllers/api/sandboxes_controller_test.rb
+++ b/test/controllers/api/sandboxes_controller_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class Api::SandboxesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    _token, @raw_token = ApiToken.generate_for(@user, name: "test")
+    @headers = { "Authorization" => "Bearer #{@raw_token}" }
+  end
+
+  test "create with project_path matching saved project inherits oidc settings" do
+    config = @user.gcp_oidc_configs.create!(
+      name: "prod",
+      project_id: "test-project-123",
+      project_number: "123456789012",
+      workload_identity_pool_id: "sandcastle",
+      workload_identity_provider_id: "sandcastle"
+    )
+    project = @user.projects.create!(
+      name: "io26",
+      path: "IO26",
+      image: SandboxManager::DEFAULT_IMAGE,
+      vnc_enabled: true,
+      vnc_geometry: "1280x900",
+      vnc_depth: 24,
+      docker_enabled: true,
+      ssh_start_tmux: true,
+      oidc_enabled: true,
+      gcp_oidc_enabled: true,
+      gcp_oidc_config: config,
+      gcp_principal_scope: "user"
+    )
+
+    post "/api/sandboxes",
+      params: {
+        name: "testbox",
+        project_path: "io26",
+        vnc_enabled: true,
+        docker_enabled: true
+      },
+      headers: @headers
+
+    assert_response :created
+    sandbox = @user.sandboxes.find_by!(name: "testbox")
+    assert_equal project.name, sandbox.project_name
+    assert_equal project.path, sandbox.home_path
+    assert_equal project.path, sandbox.data_path
+    assert sandbox.oidc_enabled?
+    assert sandbox.gcp_oidc_enabled?
+    assert_equal config, sandbox.gcp_oidc_config
+  end
+end


### PR DESCRIPTION
## Summary

Fixes sandbox creation through a saved project path so matching project presets carry their OIDC/GCP settings into the new sandbox. This covers the `io26` case where the sandbox path matched the saved project name but creation fell back to the default project and skipped OIDC injection.

Also keeps Sandcastle-owned hotfix and installer scratch files under `$SANDCASTLE_HOME/tmp`, and documents that Dockyard behavior must be edited in the sibling `../dockyard` repository rather than generated Sandcastle copies.

## Root Cause

`project_path` creation treated every value as an ad hoc subdirectory and intentionally skipped project lookup. When the CLI sent `project_path: "io26"`, the controllers used the default project settings instead of the saved `io26` project, so `oidc_enabled`, `gcp_oidc_enabled`, and `gcp_oidc_config_id` were not copied to the sandbox.

## Validation

- Verified the production failure on Sandman: `thies-test2-io26` had OIDC/GCP disabled in the DB and no injected OIDC runtime files.
- Hotfixed Sandman and verified `thies-test2-io26` now has OIDC runtime files and can mint a GCP executable JWT.
- Ran syntax checks:
  - `bash -n installer.sh`
  - `bash -n installer/installer.sh.in`
  - `bash -n installer/templates/sandcastle-admin.sh`
  - `ruby -c app/controllers/api/sandboxes_controller.rb`
  - `ruby -c app/controllers/sandboxes_controller.rb`
  - `ruby -c test/controllers/api/sandboxes_controller_test.rb`
- `bin/rails test ...` could not run locally because local Postgres is not running on `127.0.0.1:5432`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project path recognition when creating sandboxes to properly match existing projects and inherit their settings.
  * Installation process now uses safer Sandcastle-owned temporary directories instead of host system paths.

* **Documentation**
  * Updated patching instructions to reference safer temporary directory locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->